### PR TITLE
Use stdlib instead of raw pointer

### DIFF
--- a/ED.h
+++ b/ED.h
@@ -101,16 +101,17 @@ class ED
   void ComputeAnchorPoints();
   void JoinAnchorPointsUsingSortedAnchors();
   void sortAnchorsByGradValue();
-  int *sortAnchorsByGradValue1();
+  void sortAnchorsByGradValue1(std::vector<int> &A);
 
-  static int LongestChain(Chain *chains, int root);
-  static int RetrieveChainNos(Chain *chains, int root, int chainNos[]);
+  static int LongestChain(std::vector<Chain> &chains, int root);
+  static int RetrieveChainNos(std::vector<Chain> &chains, int root, std::vector<int> &chainNos);
 
   int anchorNos;
   std::vector<cv::Point> anchorPoints;
   std::vector<cv::Point> edgePoints;
 
   cv::Mat edgeImage;
+  cv::Mat dirImage;
   cv::Mat gradImage;
 
   uchar *dirImg;   // pointer to direction image data

--- a/EDCircles.cpp
+++ b/EDCircles.cpp
@@ -720,7 +720,7 @@ int EDCircles::getEllipsesNo() { return noEllipses; }
 void EDCircles::GenerateCandidateCircles()
 {
   // Now, go over the circular arcs & add them to circles1
-  auto& arcs = edarcs4->arcs;
+  auto &arcs = edarcs4->arcs;
   for (int i = 0; i < edarcs4->noArcs; i++)
   {
     if (arcs[i].isEllipse)
@@ -1600,7 +1600,7 @@ void EDCircles::JoinArcs1()
   sortArc(edarcs1->arcs, edarcs1->noArcs);
 
   int noArcs = edarcs1->noArcs;
-  auto& arcs = edarcs1->arcs;
+  auto &arcs = edarcs1->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -1859,7 +1859,7 @@ void EDCircles::JoinArcs2()
   sortArc(edarcs2->arcs, edarcs2->noArcs);
 
   int noArcs = edarcs2->noArcs;
-  auto& arcs = edarcs2->arcs;
+  auto &arcs = edarcs2->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -2108,7 +2108,7 @@ void EDCircles::JoinArcs3()
   sortArc(edarcs3->arcs, edarcs3->noArcs);
 
   int noArcs = edarcs3->noArcs;
-  auto& arcs = edarcs3->arcs;
+  auto &arcs = edarcs3->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -3409,30 +3409,30 @@ bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *
 
   std::vector<std::vector<double>> S;
   AllocateMatrix(7, 7, S);
-  
+
   std::vector<std::vector<double>> Const;
   AllocateMatrix(7, 7, Const);
-  
+
   std::vector<std::vector<double>> temp;
   AllocateMatrix(7, 7, temp);
-  
+
   std::vector<std::vector<double>> L;
   AllocateMatrix(7, 7, L);
-  
+
   std::vector<std::vector<double>> C;
   AllocateMatrix(7, 7, C);
 
   std::vector<std::vector<double>> invL;
   AllocateMatrix(7, 7, invL);
-  
+
   std::vector<double> d(7, 0);
 
   std::vector<std::vector<double>> V;
   AllocateMatrix(7, 7, V);
-  
+
   std::vector<std::vector<double>> sol;
   AllocateMatrix(7, 7, sol);
-  
+
   double tx, ty;
   int nrot = 0;
 
@@ -3544,14 +3544,17 @@ bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *
   return valid;
 }
 
-void EDCircles::AllocateMatrix(const int noRows, const int noColumns, std::vector<std::vector<double>> &matrix)
+void EDCircles::AllocateMatrix(const int noRows, const int noColumns,
+                               std::vector<std::vector<double>> &matrix)
 {
   matrix.clear();
   matrix.resize(noRows, std::vector<double>(noColumns, 0));
 }
 
-void EDCircles::A_TperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                        const int _colB)
+void EDCircles::A_TperB(const std::vector<std::vector<double>> &_A,
+                        const std::vector<std::vector<double>> &_B,
+                        std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                        const int _righB, const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _colA; p++)
@@ -3566,7 +3569,8 @@ void EDCircles::A_TperB(const std::vector<std::vector<double>> &_A, const std::v
 // Perform the Cholesky decomposition
 // Return the lower triangular L  such that L*L'=A
 //
-void EDCircles::choldc(std::vector<std::vector<double>> &a, const int n, std::vector<std::vector<double>> &l)
+void EDCircles::choldc(std::vector<std::vector<double>> &a, const int n,
+                       std::vector<std::vector<double>> &l)
 {
   int i, j, k;
   double sum;
@@ -3607,7 +3611,8 @@ void EDCircles::choldc(std::vector<std::vector<double>> &a, const int n, std::ve
   }    // end-for-outer
 }
 
-int EDCircles::inverse(const std::vector<std::vector<double>> &TB, std::vector<std::vector<double>> &InvB, const int N)
+int EDCircles::inverse(const std::vector<std::vector<double>> &TB,
+                       std::vector<std::vector<double>> &InvB, const int N)
 {
   int k, i, j, p, q;
   double mult;
@@ -3617,10 +3622,10 @@ int EDCircles::inverse(const std::vector<std::vector<double>> &TB, std::vector<s
 
   std::vector<std::vector<double>> B;
   AllocateMatrix(N + 1, N + 2, B);
-  
+
   std::vector<std::vector<double>> A;
   AllocateMatrix(N + 1, 2 * N + 2, A);
-  
+
   std::vector<std::vector<double>> C;
   AllocateMatrix(N + 1, N + 1, C);
 
@@ -3677,8 +3682,10 @@ int EDCircles::inverse(const std::vector<std::vector<double>> &TB, std::vector<s
   return (0);
 }
 
-void EDCircles::AperB_T(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                        const int _colB)
+void EDCircles::AperB_T(const std::vector<std::vector<double>> &_A,
+                        const std::vector<std::vector<double>> &_B,
+                        std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                        const int _righB, const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _colA; p++)
@@ -3689,8 +3696,10 @@ void EDCircles::AperB_T(const std::vector<std::vector<double>> &_A, const std::v
     }
 }
 
-void EDCircles::AperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                      const int _colB)
+void EDCircles::AperB(const std::vector<std::vector<double>> &_A,
+                      const std::vector<std::vector<double>> &_B,
+                      std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                      const int _righB, const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _righA; p++)
@@ -3701,7 +3710,8 @@ void EDCircles::AperB(const std::vector<std::vector<double>> &_A, const std::vec
     }
 }
 
-void EDCircles::jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d, std::vector<std::vector<double>> &v, int nrot)
+void EDCircles::jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d,
+                       std::vector<std::vector<double>> &v, int nrot)
 {
   int j, iq, ip, i;
   double tresh, theta, tau, t, sm, s, h, g, c;
@@ -3795,7 +3805,8 @@ void EDCircles::jacobi(std::vector<std::vector<double>> &a, const int n, std::ve
   // printf("Too many iterations in routine JACOBI");
 }
 
-void EDCircles::ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k, const int l, const double tau, const double s)
+void EDCircles::ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k,
+                       const int l, const double tau, const double s)
 {
   double g, h;
   g = a[i][j];

--- a/EDCircles.cpp
+++ b/EDCircles.cpp
@@ -2375,8 +2375,8 @@ void EDCircles::JoinArcs3()
   }    // end-for
 }
 
-void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
-                          double circleFitError, double *x, double *y, int noPixels)
+void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc,
+                          double r, double circleFitError, double *x, double *y, int noPixels)
 {
   circles[noCircles].xc = xc;
   circles[noCircles].yc = yc;
@@ -2393,9 +2393,9 @@ void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double x
   noCircles++;
 }
 
-void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
-                          double circleFitError, EllipseEquation *pEq, double ellipseFitError,
-                          double *x, double *y, int noPixels)
+void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc,
+                          double r, double circleFitError, EllipseEquation *pEq,
+                          double ellipseFitError, double *x, double *y, int noPixels)
 {
   circles[noCircles].xc = xc;
   circles[noCircles].yc = yc;
@@ -2412,7 +2412,6 @@ void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double x
   circles[noCircles].isEllipse = true;
 
   noCircles++;
-
 }
 
 void EDCircles::sortCircles(std::vector<Circle> &circles, int noCircles)
@@ -2829,7 +2828,8 @@ double EDCircles::ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double
 // on the ellipse periferi. These points can be used to draw the ellipse
 // noPoints must be an even number.
 //
-void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py, int noPoints)
+void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py,
+                                     int noPoints)
 {
   if (noPoints % 2) noPoints--;
   int npts = noPoints / 2;
@@ -3366,8 +3366,8 @@ bool EDCircles::CircleFit(double *x, double *y, int N, double *pxc, double *pyc,
 //------------------------------------------------------------------------------------
 // Computes the points making up a circle
 //
-void EDCircles::ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px, std::vector<double> &py,
-                                    int &noPoints)
+void EDCircles::ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px,
+                                    std::vector<double> &py, int &noPoints)
 {
   int len = (int)(TWOPI * r + 0.5);
   double angleInc = TWOPI / len;

--- a/EDCircles.cpp
+++ b/EDCircles.cpp
@@ -9,16 +9,16 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
   // If the end-points of the segment is very close to each other,
   // then directly fit a circle/ellipse instread of line fitting
   noCircles1 = 0;
-  circles1 = new Circle[(width + height) * 8];
+  circles1.resize((width + height) * 8);
 
   // ----------------------------------- DETECT LINES ---------------------------------
   int bufferSize = 0;
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines = new int[segmentNos + 1];
+  segmentStartLines.resize(segmentNos + 1, 0);
 
-  bm = new BufferManager(bufferSize * 8);
+  bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
@@ -110,7 +110,7 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
 
   // ------------------------------- DETECT ARCS ---------------------------------
 
-  info = new Info[lines.size()];
+  info.resize(lines.size());
 
   // Compute the angle information for each line segment
   for (int i = 0; i < segmentNos; i++)
@@ -163,20 +163,20 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
   // This is how much space we will allocate for circles buffers
   int maxNoOfCircles = lines.size() / 3 + noCircles1 * 2;
 
-  edarcs1 = new EDArcs(maxNoOfCircles);
+  edarcs1 = std::make_shared<EDArcs>(maxNoOfCircles);
   DetectArcs(lines);  // Detect all arcs
 
   // Try to join arcs that are almost perfectly circular.
   // Use the distance between the arc end-points as a metric in choosing in choosing arcs to join
-  edarcs2 = new EDArcs(maxNoOfCircles);
+  edarcs2 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs1();
 
   // Try to join arcs that belong to the same segment
-  edarcs3 = new EDArcs(maxNoOfCircles);
+  edarcs3 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs2();
 
   // Try to combine arcs that belong to different segments
-  edarcs4 = new EDArcs(maxNoOfCircles);  // The remaining arcs
+  edarcs4 = std::make_shared<EDArcs>(maxNoOfCircles);  // The remaining arcs
   JoinArcs3();
 
   // Finally, go over the arcs & circles, and generate candidate circles
@@ -184,14 +184,14 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
 
   //----------------------------- VALIDATE CIRCLES --------------------------
   noCircles2 = 0;
-  circles2 = new Circle[maxNoOfCircles];
+  circles2.resize(maxNoOfCircles);
   GaussianBlur(srcImage, smoothImage, Size(), 0.50);  // calculate kernel from sigma;
 
   ValidateCircles();
 
   //----------------------------- JOIN CIRCLES --------------------------
   noCircles3 = 0;
-  circles3 = new Circle[maxNoOfCircles];
+  circles3.resize(maxNoOfCircles);
   JoinCircles();
 
   noCircles = 0;
@@ -226,20 +226,6 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
 
     }  // end-else
   }    // end-for
-
-  // clean up
-  delete edarcs1;
-  delete edarcs2;
-  delete edarcs3;
-  delete edarcs4;
-
-  delete[] circles1;
-  delete[] circles2;
-  delete[] circles3;
-
-  delete bm;
-  delete[] segmentStartLines;
-  delete[] info;
 }
 
 EDCircles::EDCircles(ED obj) : EDPF(obj)
@@ -248,16 +234,16 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
   // If the end-points of the segment is very close to each other,
   // then directly fit a circle/ellipse instread of line fitting
   noCircles1 = 0;
-  circles1 = new Circle[(width + height) * 8];
+  circles1.resize((width + height) * 8);
 
   // ----------------------------------- DETECT LINES ---------------------------------
   int bufferSize = 0;
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines = new int[segmentNos + 1];
+  segmentStartLines.resize(segmentNos + 1, 0);
 
-  bm = new BufferManager(bufferSize * 8);
+  bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
@@ -348,8 +334,7 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
   segmentStartLines[segmentNos] = lines.size();
 
   // ------------------------------- DETECT ARCS ---------------------------------
-
-  info = new Info[lines.size()];
+  info.resize(lines.size());
 
   // Compute the angle information for each line segment
   for (int i = 0; i < segmentNos; i++)
@@ -402,20 +387,20 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
   // This is how much space we will allocate for circles buffers
   int maxNoOfCircles = lines.size() / 3 + noCircles1 * 2;
 
-  edarcs1 = new EDArcs(maxNoOfCircles);
+  edarcs1 = std::make_shared<EDArcs>(maxNoOfCircles);
   DetectArcs(lines);  // Detect all arcs
 
   // Try to join arcs that are almost perfectly circular.
   // Use the distance between the arc end-points as a metric in choosing in choosing arcs to join
-  edarcs2 = new EDArcs(maxNoOfCircles);
+  edarcs2 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs1();
 
   // Try to join arcs that belong to the same segment
-  edarcs3 = new EDArcs(maxNoOfCircles);
+  edarcs3 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs2();
 
   // Try to combine arcs that belong to different segments
-  edarcs4 = new EDArcs(maxNoOfCircles);  // The remaining arcs
+  edarcs4 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs3();
 
   // Finally, go over the arcs & circles, and generate candidate circles
@@ -423,14 +408,14 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
 
   //----------------------------- VALIDATE CIRCLES --------------------------
   noCircles2 = 0;
-  circles2 = new Circle[maxNoOfCircles];
+  circles2.resize(maxNoOfCircles);
   GaussianBlur(srcImage, smoothImage, Size(), 0.50);  // calculate kernel from sigma;
 
   ValidateCircles();
 
   //----------------------------- JOIN CIRCLES --------------------------
   noCircles3 = 0;
-  circles3 = new Circle[maxNoOfCircles];
+  circles3.resize(maxNoOfCircles);
   JoinCircles();
 
   noCircles = 0;
@@ -465,20 +450,6 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
 
     }  // end-else
   }    // end-for
-
-  // clean up
-  delete edarcs1;
-  delete edarcs2;
-  delete edarcs3;
-  delete edarcs4;
-
-  delete[] circles1;
-  delete[] circles2;
-  delete[] circles3;
-
-  delete bm;
-  delete[] segmentStartLines;
-  delete[] info;
 }
 
 EDCircles::EDCircles(EDColor obj) : EDPF(obj)
@@ -487,16 +458,16 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
   // If the end-points of the segment is very close to each other,
   // then directly fit a circle/ellipse instread of line fitting
   noCircles1 = 0;
-  circles1 = new Circle[(width + height) * 8];
+  circles1.resize((width + height) * 8);
 
   // ----------------------------------- DETECT LINES ---------------------------------
   int bufferSize = 0;
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines = new int[segmentNos + 1];
+  segmentStartLines.resize(segmentNos + 1, 0);
 
-  bm = new BufferManager(bufferSize * 8);
+  bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
@@ -588,7 +559,7 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
 
   // ------------------------------- DETECT ARCS ---------------------------------
 
-  info = new Info[lines.size()];
+  info.resize(lines.size());
 
   // Compute the angle information for each line segment
   for (int i = 0; i < segmentNos; i++)
@@ -641,20 +612,20 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
   // This is how much space we will allocate for circles buffers
   int maxNoOfCircles = lines.size() / 3 + noCircles1 * 2;
 
-  edarcs1 = new EDArcs(maxNoOfCircles);
+  edarcs1 = std::make_shared<EDArcs>(maxNoOfCircles);
   DetectArcs(lines);  // Detect all arcs
 
   // Try to join arcs that are almost perfectly circular.
   // Use the distance between the arc end-points as a metric in choosing in choosing arcs to join
-  edarcs2 = new EDArcs(maxNoOfCircles);
+  edarcs2 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs1();
 
   // Try to join arcs that belong to the same segment
-  edarcs3 = new EDArcs(maxNoOfCircles);
+  edarcs3 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs2();
 
   // Try to combine arcs that belong to different segments
-  edarcs4 = new EDArcs(maxNoOfCircles);  // The remaining arcs
+  edarcs4 = std::make_shared<EDArcs>(maxNoOfCircles);
   JoinArcs3();
 
   // Finally, go over the arcs & circles, and generate candidate circles
@@ -707,20 +678,6 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
 
     }  // end-else
   }    // end-for
-
-  // clean up
-  delete edarcs1;
-  delete edarcs2;
-  delete edarcs3;
-  delete edarcs4;
-
-  delete[] circles1;
-  // delete[] circles2;
-  // delete[] circles3;
-
-  delete bm;
-  delete[] segmentStartLines;
-  delete[] info;
 }
 
 cv::Mat EDCircles::drawResult(bool onImage, ImageStyle style)
@@ -1212,14 +1169,14 @@ void EDCircles::ValidateCircles()
   double min = width;
   if (height < min) min = height;
 
-  double *px = new double[8 * (width + height)];
-  double *py = new double[8 * (width + height)];
+  std::vector<double> px(8 * (width + height));
+  std::vector<double> py(8 * (width + height));
 
   // logNT & LUT for NFA computation
   double logNT = 2 * log10((double)(width * height)) + log10((double)(width + height));
 
   int lutSize = (width + height) / 8;
-  nfa = new NFALUT(lutSize, prob, logNT);  // create look up table
+  nfa = std::make_shared<NFALUT>(lutSize, prob, logNT);  // create look up table
 
   // Validate circles & ellipses
   bool validateAgain;
@@ -1251,7 +1208,7 @@ void EDCircles::ValidateCircles()
     }
     else
     {
-      ComputeCirclePoints(xc, yc, radius, px, py, &noPoints);
+      ComputeCirclePoints(xc, yc, radius, px, py, noPoints);
     }  // end-else
 
     int pr = -1;  // previous row
@@ -1456,19 +1413,15 @@ void EDCircles::ValidateCircles()
   }  // end-for
 
   noCircles2 = count;
-
-  delete[] px;
-  delete[] py;
-  delete nfa;
 }
 
 void EDCircles::JoinCircles()
 {
   // Sort the circles wrt their radius
-  sortCircle(circles2, noCircles2);
+  sortCircles(circles2, noCircles2);
 
   int noCircles = noCircles2;
-  Circle *circles = circles2;
+  auto &circles = circles2;
 
   for (int i = 0; i < noCircles; i++)
   {
@@ -1479,10 +1432,9 @@ void EDCircles::JoinCircles()
     }  // end-if
   }    // end-for
 
-  bool *taken = new bool[noCircles];
-  for (int i = 0; i < noCircles; i++) taken[i] = false;
+  std::vector<bool> taken(noCircles, false);
 
-  int *candidateCircles = new int[noCircles];
+  std::vector<int> candidateCircles(noCircles, 0);
   int noCandidateCircles;
 
   for (int i = 0; i < noCircles; i++)
@@ -1638,9 +1590,6 @@ void EDCircles::JoinCircles()
       noCircles3++;
     }  // end-else
   }    // end-for
-
-  delete[] taken;
-  delete[] candidateCircles;
 }
 
 void EDCircles::JoinArcs1()
@@ -1653,8 +1602,7 @@ void EDCircles::JoinArcs1()
   int noArcs = edarcs1->noArcs;
   MyArc *arcs = edarcs1->arcs;
 
-  bool *taken = new bool[noArcs];
-  for (int i = 0; i < noArcs; i++) taken[i] = false;
+  std::vector<bool> taken(noArcs, false);
 
   struct CandidateArc
   {
@@ -1664,7 +1612,7 @@ void EDCircles::JoinArcs1()
     double dist;  // min distance between the end points
   };
 
-  CandidateArc *candidateArcs = new CandidateArc[noArcs];
+  std::vector<CandidateArc> candidateArcs(noArcs);
   int noCandidateArcs;
 
   for (int i = 0; i < noArcs; i++)
@@ -1901,9 +1849,6 @@ void EDCircles::JoinArcs1()
       bm->move(NoPixels);
     }  // end-if
   }    // end-for
-
-  delete[] taken;
-  delete[] candidateArcs;
 }
 
 void EDCircles::JoinArcs2()
@@ -1916,8 +1861,7 @@ void EDCircles::JoinArcs2()
   int noArcs = edarcs2->noArcs;
   MyArc *arcs = edarcs2->arcs;
 
-  bool *taken = new bool[noArcs];
-  for (int i = 0; i < noArcs; i++) taken[i] = false;
+  std::vector<bool> taken(noArcs, false);
 
   struct CandidateArc
   {
@@ -1927,7 +1871,7 @@ void EDCircles::JoinArcs2()
     double dist;  // min distance between the end points
   };
 
-  CandidateArc *candidateArcs = new CandidateArc[noArcs];
+  std::vector<CandidateArc> candidateArcs(noArcs);
   int noCandidateArcs;
 
   for (int i = 0; i < noArcs; i++)
@@ -2154,9 +2098,6 @@ void EDCircles::JoinArcs2()
       bm->move(NoPixels);
     }  // end-if
   }    // end-for
-
-  delete[] taken;
-  delete[] candidateArcs;
 }
 
 void EDCircles::JoinArcs3()
@@ -2169,8 +2110,7 @@ void EDCircles::JoinArcs3()
   int noArcs = edarcs3->noArcs;
   MyArc *arcs = edarcs3->arcs;
 
-  bool *taken = new bool[noArcs];
-  for (int i = 0; i < noArcs; i++) taken[i] = false;
+  std::vector<bool> taken(noArcs, false);
 
   struct CandidateArc
   {
@@ -2180,7 +2120,7 @@ void EDCircles::JoinArcs3()
     double dist;  // min distance between the end points
   };
 
-  CandidateArc *candidateArcs = new CandidateArc[noArcs];
+  std::vector<CandidateArc> candidateArcs(noArcs);
   int noCandidateArcs;
 
   for (int i = 0; i < noArcs; i++)
@@ -2433,13 +2373,10 @@ void EDCircles::JoinArcs3()
       bm->move(NoPixels);
     }  // end-if
   }    // end-for
-
-  delete[] taken;
-  delete[] candidateArcs;
 }
 
-Circle *EDCircles::addCircle(Circle *circles, int &noCircles, double xc, double yc, double r,
-                             double circleFitError, double *x, double *y, int noPixels)
+void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
+                          double circleFitError, double *x, double *y, int noPixels)
 {
   circles[noCircles].xc = xc;
   circles[noCircles].yc = yc;
@@ -2454,13 +2391,11 @@ Circle *EDCircles::addCircle(Circle *circles, int &noCircles, double xc, double 
   circles[noCircles].isEllipse = false;
 
   noCircles++;
-
-  return &circles[noCircles - 1];
 }
 
-Circle *EDCircles::addCircle(Circle *circles, int &noCircles, double xc, double yc, double r,
-                             double circleFitError, EllipseEquation *pEq, double ellipseFitError,
-                             double *x, double *y, int noPixels)
+void EDCircles::addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
+                          double circleFitError, EllipseEquation *pEq, double ellipseFitError,
+                          double *x, double *y, int noPixels)
 {
   circles[noCircles].xc = xc;
   circles[noCircles].yc = yc;
@@ -2478,10 +2413,9 @@ Circle *EDCircles::addCircle(Circle *circles, int &noCircles, double xc, double 
 
   noCircles++;
 
-  return &circles[noCircles - 1];
 }
 
-void EDCircles::sortCircles(Circle *circles, int noCircles)
+void EDCircles::sortCircles(std::vector<Circle> &circles, int noCircles)
 {
   for (int i = 0; i < noCircles - 1; i++)
   {
@@ -2895,7 +2829,7 @@ double EDCircles::ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double
 // on the ellipse periferi. These points can be used to draw the ellipse
 // noPoints must be an even number.
 //
-void EDCircles::ComputeEllipsePoints(double *pvec, double *px, double *py, int noPoints)
+void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py, int noPoints)
 {
   if (noPoints % 2) noPoints--;
   int npts = noPoints / 2;
@@ -3432,8 +3366,8 @@ bool EDCircles::CircleFit(double *x, double *y, int N, double *pxc, double *pyc,
 //------------------------------------------------------------------------------------
 // Computes the points making up a circle
 //
-void EDCircles::ComputeCirclePoints(double xc, double yc, double r, double *px, double *py,
-                                    int *noPoints)
+void EDCircles::ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px, std::vector<double> &py,
+                                    int &noPoints)
 {
   int len = (int)(TWOPI * r + 0.5);
   double angleInc = TWOPI / len;
@@ -3455,26 +3389,7 @@ void EDCircles::ComputeCirclePoints(double xc, double yc, double r, double *px, 
     count++;
   }  // end-while
 
-  *noPoints = count;
-}
-
-void EDCircles::sortCircle(Circle *circles, int noCircles)
-{
-  for (int i = 0; i < noCircles - 1; i++)
-  {
-    int max = i;
-    for (int j = i + 1; j < noCircles; j++)
-    {
-      if (circles[j].r > circles[max].r) max = j;
-    }  // end-for
-
-    if (max != i)
-    {
-      Circle t = circles[i];
-      circles[i] = circles[max];
-      circles[max] = t;
-    }  // end-if
-  }    // end-for
+  noPoints = count;
 }
 
 bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult, int mode)

--- a/EDCircles.cpp
+++ b/EDCircles.cpp
@@ -720,7 +720,7 @@ int EDCircles::getEllipsesNo() { return noEllipses; }
 void EDCircles::GenerateCandidateCircles()
 {
   // Now, go over the circular arcs & add them to circles1
-  MyArc *arcs = edarcs4->arcs;
+  auto& arcs = edarcs4->arcs;
   for (int i = 0; i < edarcs4->noArcs; i++)
   {
     if (arcs[i].isEllipse)
@@ -1600,7 +1600,7 @@ void EDCircles::JoinArcs1()
   sortArc(edarcs1->arcs, edarcs1->noArcs);
 
   int noArcs = edarcs1->noArcs;
-  MyArc *arcs = edarcs1->arcs;
+  auto& arcs = edarcs1->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -1859,7 +1859,7 @@ void EDCircles::JoinArcs2()
   sortArc(edarcs2->arcs, edarcs2->noArcs);
 
   int noArcs = edarcs2->noArcs;
-  MyArc *arcs = edarcs2->arcs;
+  auto& arcs = edarcs2->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -2108,7 +2108,7 @@ void EDCircles::JoinArcs3()
   sortArc(edarcs3->arcs, edarcs3->noArcs);
 
   int noArcs = edarcs3->noArcs;
-  MyArc *arcs = edarcs3->arcs;
+  auto& arcs = edarcs3->arcs;
 
   std::vector<bool> taken(noArcs, false);
 
@@ -2834,30 +2834,56 @@ void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std:
   if (noPoints % 2) noPoints--;
   int npts = noPoints / 2;
 
-  double **u = AllocateMatrix(3, npts + 1);
-  double **Aiu = AllocateMatrix(3, npts + 1);
-  double **L = AllocateMatrix(3, npts + 1);
-  double **B = AllocateMatrix(3, npts + 1);
-  double **Xpos = AllocateMatrix(3, npts + 1);
-  double **Xneg = AllocateMatrix(3, npts + 1);
-  double **ss1 = AllocateMatrix(3, npts + 1);
-  double **ss2 = AllocateMatrix(3, npts + 1);
-  double *lambda = new double[npts + 1];
-  double **uAiu = AllocateMatrix(3, npts + 1);
-  double **A = AllocateMatrix(3, 3);
-  double **Ai = AllocateMatrix(3, 3);
-  double **Aib = AllocateMatrix(3, 2);
-  double **b = AllocateMatrix(3, 2);
-  double **r1 = AllocateMatrix(2, 2);
+  std::vector<std::vector<double>> u;
+  AllocateMatrix(3, npts + 1, u);
+
+  std::vector<std::vector<double>> Aiu;
+  AllocateMatrix(3, npts + 1, Aiu);
+
+  std::vector<std::vector<double>> L;
+  AllocateMatrix(3, npts + 1, L);
+
+  std::vector<std::vector<double>> B;
+  AllocateMatrix(3, npts + 1, B);
+
+  std::vector<std::vector<double>> Xpos;
+  AllocateMatrix(3, npts + 1, Xpos);
+
+  std::vector<std::vector<double>> Xneg;
+  AllocateMatrix(3, npts + 1, Xneg);
+
+  std::vector<std::vector<double>> ss1;
+  AllocateMatrix(3, npts + 1, ss1);
+
+  std::vector<std::vector<double>> ss2;
+  AllocateMatrix(3, npts + 1, ss2);
+
+  std::vector<std::vector<double>> uAiu;
+  AllocateMatrix(3, npts + 1, uAiu);
+
+  std::vector<std::vector<double>> A;
+  AllocateMatrix(3, 3, A);
+
+  std::vector<std::vector<double>> Ai;
+  AllocateMatrix(3, 3, Ai);
+
+  std::vector<std::vector<double>> Aib;
+  AllocateMatrix(3, 2, Aib);
+
+  std::vector<std::vector<double>> b;
+  AllocateMatrix(3, 2, b);
+
+  std::vector<std::vector<double>> r1;
+  AllocateMatrix(2, 2, r1);
+
   double Ao, Ax, Ay, Axx, Ayy, Axy;
+  std::vector<double> lambda(npts + 1, 0);
 
   double pi = 3.14781;
   double theta;
   int i;
   int j;
   double kk;
-
-  memset(lambda, 0, sizeof(double) * (npts + 1));
 
   Ao = pvec[6];
   Ax = pvec[4];
@@ -2934,22 +2960,6 @@ void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std:
       py[j - 1 + npts] = Xneg[2][j];
     }
   }
-
-  DeallocateMatrix(u, 3);
-  DeallocateMatrix(Aiu, 3);
-  DeallocateMatrix(L, 3);
-  DeallocateMatrix(B, 3);
-  DeallocateMatrix(Xpos, 3);
-  DeallocateMatrix(Xneg, 3);
-  DeallocateMatrix(ss1, 3);
-  DeallocateMatrix(ss2, 3);
-  delete[] lambda;
-  DeallocateMatrix(uAiu, 3);
-  DeallocateMatrix(A, 3);
-  DeallocateMatrix(Ai, 3);
-  DeallocateMatrix(Aib, 3);
-  DeallocateMatrix(b, 3);
-  DeallocateMatrix(r1, 2);
 }
 
 // Tries to join the last two arcs if their end-points are very close to each other
@@ -2957,7 +2967,7 @@ void EDCircles::ComputeEllipsePoints(double *pvec, std::vector<double> &px, std:
 // is broken due to a noisy patch along the arc, and the long arc is broken into two or more arcs.
 // This function will join such broken arcs
 //
-void EDCircles::joinLastTwoArcs(MyArc *arcs, int &noArcs)
+void EDCircles::joinLastTwoArcs(std::vector<MyArc> &arcs, int &noArcs)
 {
   if (noArcs < 2) return;
 
@@ -3017,7 +3027,7 @@ void EDCircles::joinLastTwoArcs(MyArc *arcs, int &noArcs)
 //-----------------------------------------------------------------------
 // Add a new arc to arcs
 //
-void EDCircles::addArc(MyArc *arcs, int &noArcs, double xc, double yc, double r,
+void EDCircles::addArc(std::vector<MyArc> &arcs, int &noArcs, double xc, double yc, double r,
                        double circleFitError, double sTheta, double eTheta, int turn, int segmentNo,
                        int sx, int sy, int ex, int ey, double *x, double *y, int noPixels,
                        double overlapRatio)
@@ -3055,7 +3065,7 @@ void EDCircles::addArc(MyArc *arcs, int &noArcs, double xc, double yc, double r,
 //-------------------------------------------------------------------------
 // Add an elliptic arc to the list of arcs
 //
-void EDCircles::addArc(MyArc *arcs, int &noArcs, double xc, double yc, double r,
+void EDCircles::addArc(std::vector<MyArc> &arcs, int &noArcs, double xc, double yc, double r,
                        double circleFitError, double sTheta, double eTheta, int turn, int segmentNo,
                        EllipseEquation *pEq, double ellipseFitError, int sx, int sy, int ex, int ey,
                        double *x, double *y, int noPixels, double overlapRatio)
@@ -3262,7 +3272,7 @@ void EDCircles::ComputeStartAndEndAngles(double xc, double yc, double r, double 
   *peTheta = eTheta;
 }
 
-void EDCircles::sortArc(MyArc *arcs, int noArcs)
+void EDCircles::sortArc(std::vector<MyArc> &arcs, int noArcs)
 {
   for (int i = 0; i < noArcs - 1; i++)
   {
@@ -3394,21 +3404,37 @@ void EDCircles::ComputeCirclePoints(double xc, double yc, double r, std::vector<
 
 bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult, int mode)
 {
-  double **D = AllocateMatrix(noPoints + 1, 7);
-  double **S = AllocateMatrix(7, 7);
-  double **Const = AllocateMatrix(7, 7);
-  double **temp = AllocateMatrix(7, 7);
-  double **L = AllocateMatrix(7, 7);
-  double **C = AllocateMatrix(7, 7);
+  std::vector<std::vector<double>> D;
+  AllocateMatrix(noPoints + 1, 7, D);
 
-  double **invL = AllocateMatrix(7, 7);
-  double *d = new double[7];
-  double **V = AllocateMatrix(7, 7);
-  double **sol = AllocateMatrix(7, 7);
+  std::vector<std::vector<double>> S;
+  AllocateMatrix(7, 7, S);
+  
+  std::vector<std::vector<double>> Const;
+  AllocateMatrix(7, 7, Const);
+  
+  std::vector<std::vector<double>> temp;
+  AllocateMatrix(7, 7, temp);
+  
+  std::vector<std::vector<double>> L;
+  AllocateMatrix(7, 7, L);
+  
+  std::vector<std::vector<double>> C;
+  AllocateMatrix(7, 7, C);
+
+  std::vector<std::vector<double>> invL;
+  AllocateMatrix(7, 7, invL);
+  
+  std::vector<double> d(7, 0);
+
+  std::vector<std::vector<double>> V;
+  AllocateMatrix(7, 7, V);
+  
+  std::vector<std::vector<double>> sol;
+  AllocateMatrix(7, 7, sol);
+  
   double tx, ty;
   int nrot = 0;
-
-  memset(d, 0, sizeof(double) * 7);
 
   switch (mode)
   {
@@ -3509,17 +3535,6 @@ bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *
     }  // end-for
   }    // end-if
 
-  DeallocateMatrix(D, noPoints + 1);
-  DeallocateMatrix(S, 7);
-  DeallocateMatrix(Const, 7);
-  DeallocateMatrix(temp, 7);
-  DeallocateMatrix(L, 7);
-  DeallocateMatrix(C, 7);
-  DeallocateMatrix(invL, 7);
-  delete[] d;
-  DeallocateMatrix(V, 7);
-  DeallocateMatrix(sol, 7);
-
   if (valid)
   {
     int len = (int)computeEllipsePerimeter(pResult);
@@ -3529,21 +3544,14 @@ bool EDCircles::EllipseFit(double *x, double *y, int noPoints, EllipseEquation *
   return valid;
 }
 
-double **EDCircles::AllocateMatrix(int noRows, int noColumns)
+void EDCircles::AllocateMatrix(const int noRows, const int noColumns, std::vector<std::vector<double>> &matrix)
 {
-  double **m = new double *[noRows];
-
-  for (int i = 0; i < noRows; i++)
-  {
-    m[i] = new double[noColumns];
-    memset(m[i], 0, sizeof(double) * noColumns);
-  }  // end-for
-
-  return m;
+  matrix.clear();
+  matrix.resize(noRows, std::vector<double>(noColumns, 0));
 }
 
-void EDCircles::A_TperB(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                        int _colB)
+void EDCircles::A_TperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                        const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _colA; p++)
@@ -3558,12 +3566,11 @@ void EDCircles::A_TperB(double **_A, double **_B, double **_res, int _righA, int
 // Perform the Cholesky decomposition
 // Return the lower triangular L  such that L*L'=A
 //
-void EDCircles::choldc(double **a, int n, double **l)
+void EDCircles::choldc(std::vector<std::vector<double>> &a, const int n, std::vector<std::vector<double>> &l)
 {
   int i, j, k;
   double sum;
-  double *p = new double[n + 1];
-  memset(p, 0, sizeof(double) * (n + 1));
+  std::vector<double> p(n + 1, 0);
 
   for (i = 1; i <= n; i++)
   {
@@ -3598,21 +3605,26 @@ void EDCircles::choldc(double **a, int n, double **l)
       }
     }  // end-for-inner
   }    // end-for-outer
-
-  delete[] p;
 }
 
-int EDCircles::inverse(double **TB, double **InvB, int N)
+int EDCircles::inverse(const std::vector<std::vector<double>> &TB, std::vector<std::vector<double>> &InvB, const int N)
 {
   int k, i, j, p, q;
   double mult;
   double D, temp;
   double maxpivot;
   int npivot;
-  double **B = AllocateMatrix(N + 1, N + 2);
-  double **A = AllocateMatrix(N + 1, 2 * N + 2);
-  double **C = AllocateMatrix(N + 1, N + 1);
-  double eps = 10e-20;
+
+  std::vector<std::vector<double>> B;
+  AllocateMatrix(N + 1, N + 2, B);
+  
+  std::vector<std::vector<double>> A;
+  AllocateMatrix(N + 1, 2 * N + 2, A);
+  
+  std::vector<std::vector<double>> C;
+  AllocateMatrix(N + 1, N + 1, C);
+
+  const double eps = 10e-20;
 
   for (k = 1; k <= N; k++)
     for (j = 1; j <= N; j++) B[k][j] = TB[k][j];
@@ -3655,11 +3667,6 @@ int EDCircles::inverse(double **TB, double **InvB, int N)
     }
     else
     {  // printf("\n The matrix may be singular !!") ;
-
-      DeallocateMatrix(B, N + 1);
-      DeallocateMatrix(A, N + 1);
-      DeallocateMatrix(C, N + 1);
-
       return (-1);
     }  // end-else
   }
@@ -3667,21 +3674,11 @@ int EDCircles::inverse(double **TB, double **InvB, int N)
   for (k = 1, p = 1; k <= N; k++, p++)
     for (j = N + 2, q = 1; j <= 2 * N + 1; j++, q++) InvB[p][q] = A[k][j];
 
-  DeallocateMatrix(B, N + 1);
-  DeallocateMatrix(A, N + 1);
-  DeallocateMatrix(C, N + 1);
-
   return (0);
 }
 
-void EDCircles::DeallocateMatrix(double **m, int noRows)
-{
-  for (int i = 0; i < noRows; i++) delete[] m[i];
-  delete[] m;
-}
-
-void EDCircles::AperB_T(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                        int _colB)
+void EDCircles::AperB_T(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                        const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _colA; p++)
@@ -3692,8 +3689,8 @@ void EDCircles::AperB_T(double **_A, double **_B, double **_res, int _righA, int
     }
 }
 
-void EDCircles::AperB(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                      int _colB)
+void EDCircles::AperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                      const int _colB)
 {
   int p, q, l;
   for (p = 1; p <= _righA; p++)
@@ -3704,15 +3701,13 @@ void EDCircles::AperB(double **_A, double **_B, double **_res, int _righA, int _
     }
 }
 
-void EDCircles::jacobi(double **a, int n, double d[], double **v, int nrot)
+void EDCircles::jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d, std::vector<std::vector<double>> &v, int nrot)
 {
   int j, iq, ip, i;
   double tresh, theta, tau, t, sm, s, h, g, c;
 
-  double *b = new double[n + 1];
-  double *z = new double[n + 1];
-  memset(b, 0, sizeof(double) * (n + 1));
-  memset(z, 0, sizeof(double) * (n + 1));
+  std::vector<double> b(n + 1, 0);
+  std::vector<double> z(n + 1, 0);
 
   for (ip = 1; ip <= n; ip++)
   {
@@ -3734,8 +3729,6 @@ void EDCircles::jacobi(double **a, int n, double d[], double **v, int nrot)
     }
     if (sm == 0.0)
     {
-      delete[] b;
-      delete[] z;
       return;
     }
     if (i < 4)
@@ -3800,11 +3793,9 @@ void EDCircles::jacobi(double **a, int n, double d[], double **v, int nrot)
     }
   }
   // printf("Too many iterations in routine JACOBI");
-  delete[] b;
-  delete[] z;
 }
 
-void EDCircles::ROTATE(double **a, int i, int j, int k, int l, double tau, double s)
+void EDCircles::ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k, const int l, const double tau, const double s)
 {
   double g, h;
   g = a[i][j];

--- a/EDCircles.h
+++ b/EDCircles.h
@@ -225,9 +225,7 @@ struct BufferManager
     index = 0;
   }  // end-BufferManager
 
-  ~BufferManager()
-  {
-  }  // end-~BufferManager
+  ~BufferManager() {}  // end-~BufferManager
 
   double *getX() { return &x[index]; }
   double *getY() { return &y[index]; }
@@ -301,17 +299,28 @@ class EDCircles : public EDPF
   // ellipse utility functions
   static bool EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult,
                          int mode = FPF);
-  static void AllocateMatrix(const int noRows, const int noColumns, std::vector<std::vector<double>> &matrix);
-  static void A_TperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                      const int _colB);
-  static void choldc(std::vector<std::vector<double>> &a, const int n, std::vector<std::vector<double>> &l);
-  static int inverse(const std::vector<std::vector<double>> &TB, std::vector<std::vector<double>> &InvB, const int N);
-  static void AperB_T(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                      const int _colB);
-  static void AperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
-                    const int _colB);
-  static void jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d, std::vector<std::vector<double>> &v, int nrot);
-  static void ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k, const int l, const double tau, const double s);
+  static void AllocateMatrix(const int noRows, const int noColumns,
+                             std::vector<std::vector<double>> &matrix);
+  static void A_TperB(const std::vector<std::vector<double>> &_A,
+                      const std::vector<std::vector<double>> &_B,
+                      std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                      const int _righB, const int _colB);
+  static void choldc(std::vector<std::vector<double>> &a, const int n,
+                     std::vector<std::vector<double>> &l);
+  static int inverse(const std::vector<std::vector<double>> &TB,
+                     std::vector<std::vector<double>> &InvB, const int N);
+  static void AperB_T(const std::vector<std::vector<double>> &_A,
+                      const std::vector<std::vector<double>> &_B,
+                      std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                      const int _righB, const int _colB);
+  static void AperB(const std::vector<std::vector<double>> &_A,
+                    const std::vector<std::vector<double>> &_B,
+                    std::vector<std::vector<double>> &_res, const int _righA, const int _colA,
+                    const int _righB, const int _colB);
+  static void jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d,
+                     std::vector<std::vector<double>> &v, int nrot);
+  static void ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k,
+                     const int l, const double tau, const double s);
   static double computeEllipsePerimeter(EllipseEquation *eq);
   static double ComputeEllipseError(EllipseEquation *eq, double *px, double *py, int noPoints);
   static double ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double *pxc, double *pyc,

--- a/EDCircles.h
+++ b/EDCircles.h
@@ -198,37 +198,35 @@ struct AngleSet
 
 struct EDArcs
 {
-  MyArc *arcs;
+  std::vector<MyArc> arcs;
   int noArcs;
 
  public:
   EDArcs(int size = 10000)
   {
-    arcs = new MyArc[size];
+    arcs.resize(size);
     noArcs = 0;
   }  // end-EDArcs
 
-  ~EDArcs() { delete[] arcs; }  // end-~EDArcs
+  ~EDArcs() {}  // end-~EDArcs
 };
 
 //-----------------------------------------------------------------
 // Buffer manager
 struct BufferManager
 {
-  double *x, *y;
+  std::vector<double> x, y;
   int index;
 
   BufferManager(int maxSize)
   {
-    x = new double[maxSize];
-    y = new double[maxSize];
+    x.resize(maxSize, 0);
+    y.resize(maxSize, 0);
     index = 0;
   }  // end-BufferManager
 
   ~BufferManager()
   {
-    delete[] x;
-    delete[] y;
   }  // end-~BufferManager
 
   double *getX() { return &x[index]; }
@@ -303,18 +301,17 @@ class EDCircles : public EDPF
   // ellipse utility functions
   static bool EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult,
                          int mode = FPF);
-  static double **AllocateMatrix(int noRows, int noColumns);
-  static void A_TperB(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                      int _colB);
-  static void choldc(double **a, int n, double **l);
-  static int inverse(double **TB, double **InvB, int N);
-  static void DeallocateMatrix(double **m, int noRows);
-  static void AperB_T(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                      int _colB);
-  static void AperB(double **_A, double **_B, double **_res, int _righA, int _colA, int _righB,
-                    int _colB);
-  static void jacobi(double **a, int n, double d[], double **v, int nrot);
-  static void ROTATE(double **a, int i, int j, int k, int l, double tau, double s);
+  static void AllocateMatrix(const int noRows, const int noColumns, std::vector<std::vector<double>> &matrix);
+  static void A_TperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                      const int _colB);
+  static void choldc(std::vector<std::vector<double>> &a, const int n, std::vector<std::vector<double>> &l);
+  static int inverse(const std::vector<std::vector<double>> &TB, std::vector<std::vector<double>> &InvB, const int N);
+  static void AperB_T(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                      const int _colB);
+  static void AperB(const std::vector<std::vector<double>> &_A, const std::vector<std::vector<double>> &_B, std::vector<std::vector<double>> &_res, const int _righA, const int _colA, const int _righB,
+                    const int _colB);
+  static void jacobi(std::vector<std::vector<double>> &a, const int n, std::vector<double> &d, std::vector<std::vector<double>> &v, int nrot);
+  static void ROTATE(std::vector<std::vector<double>> &a, const int i, const int j, const int k, const int l, const double tau, const double s);
   static double computeEllipsePerimeter(EllipseEquation *eq);
   static double ComputeEllipseError(EllipseEquation *eq, double *px, double *py, int noPoints);
   static double ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double *pxc, double *pyc,
@@ -324,12 +321,12 @@ class EDCircles : public EDPF
                                    int noPoints);
 
   // arc utility functions
-  static void joinLastTwoArcs(MyArc *arcs, int &noArcs);
-  static void addArc(MyArc *arcs, int &noArchs, double xc, double yc, double r,
+  static void joinLastTwoArcs(std::vector<MyArc> &arcs, int &noArcs);
+  static void addArc(std::vector<MyArc> &arcs, int &noArchs, double xc, double yc, double r,
                      double circleFitError,  // Circular arc
                      double sTheta, double eTheta, int turn, int segmentNo, int sx, int sy, int ex,
                      int ey, double *x, double *y, int noPixels, double overlapRatio = 0.0);
-  static void addArc(MyArc *arcs, int &noArchs, double xc, double yc, double r,
+  static void addArc(std::vector<MyArc> &arcs, int &noArchs, double xc, double yc, double r,
                      double circleFitError,  // Elliptic arc
                      double sTheta, double eTheta, int turn, int segmentNo, EllipseEquation *pEq,
                      double ellipseFitError, int sx, int sy, int ex, int ey, double *x, double *y,
@@ -338,7 +335,7 @@ class EDCircles : public EDPF
   static void ComputeStartAndEndAngles(double xc, double yc, double r, double *x, double *y,
                                        int len, double *psTheta, double *peTheta);
 
-  static void sortArc(MyArc *arcs, int noArcs);
+  static void sortArc(std::vector<MyArc> &arcs, int noArcs);
 };
 
 #endif  // ! _EDCIRCLES_

--- a/EDCircles.h
+++ b/EDCircles.h
@@ -289,16 +289,16 @@ class EDCircles : public EDPF
   void JoinArcs3();
 
   // circle utility functions
-  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
-                        double circleFitError, double *x, double *y, int noPixels);
-  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
-                        double circleFitError, EllipseEquation *pEq, double ellipseFitError,
-                        double *x, double *y, int noPixels);
+  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc,
+                        double r, double circleFitError, double *x, double *y, int noPixels);
+  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc,
+                        double r, double circleFitError, EllipseEquation *pEq,
+                        double ellipseFitError, double *x, double *y, int noPixels);
   static void sortCircles(std::vector<Circle> &circles, int noCircles);
   static bool CircleFit(double *x, double *y, int N, double *pxc, double *pyc, double *pr,
                         double *pe);
-  static void ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px, std::vector<double> &py,
-                                  int &noPoints);
+  static void ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px,
+                                  std::vector<double> &py, int &noPoints);
 
   // ellipse utility functions
   static bool EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult,
@@ -320,7 +320,8 @@ class EDCircles : public EDPF
   static double ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double *pxc, double *pyc,
                                                    double *pmajorAxisLength,
                                                    double *pminorAxisLength);
-  static void ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py, int noPoints);
+  static void ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py,
+                                   int noPoints);
 
   // arc utility functions
   static void joinLastTwoArcs(MyArc *arcs, int &noArcs);

--- a/EDCircles.h
+++ b/EDCircles.h
@@ -263,22 +263,22 @@ class EDCircles : public EDPF
   std::vector<mCircle> circles;
   std::vector<mEllipse> ellipses;
 
-  Circle *circles1;
-  Circle *circles2;
-  Circle *circles3;
+  std::vector<Circle> circles1;
+  std::vector<Circle> circles2;
+  std::vector<Circle> circles3;
   int noCircles1;
   int noCircles2;
   int noCircles3;
 
-  EDArcs *edarcs1;
-  EDArcs *edarcs2;
-  EDArcs *edarcs3;
-  EDArcs *edarcs4;
+  std::shared_ptr<EDArcs> edarcs1;
+  std::shared_ptr<EDArcs> edarcs2;
+  std::shared_ptr<EDArcs> edarcs3;
+  std::shared_ptr<EDArcs> edarcs4;
 
-  int *segmentStartLines;
-  BufferManager *bm;
-  Info *info;
-  NFALUT *nfa;
+  std::vector<int> segmentStartLines;
+  std::shared_ptr<BufferManager> bm;
+  std::vector<Info> info;
+  std::shared_ptr<NFALUT> nfa;
 
   void GenerateCandidateCircles();
   void DetectArcs(std::vector<LineSegment> lines);
@@ -289,17 +289,16 @@ class EDCircles : public EDPF
   void JoinArcs3();
 
   // circle utility functions
-  static Circle *addCircle(Circle *circles, int &noCircles, double xc, double yc, double r,
-                           double circleFitError, double *x, double *y, int noPixels);
-  static Circle *addCircle(Circle *circles, int &noCircles, double xc, double yc, double r,
-                           double circleFitError, EllipseEquation *pEq, double ellipseFitError,
-                           double *x, double *y, int noPixels);
-  static void sortCircles(Circle *circles, int noCircles);
+  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
+                        double circleFitError, double *x, double *y, int noPixels);
+  static void addCircle(std::vector<Circle> &circles, int &noCircles, double xc, double yc, double r,
+                        double circleFitError, EllipseEquation *pEq, double ellipseFitError,
+                        double *x, double *y, int noPixels);
+  static void sortCircles(std::vector<Circle> &circles, int noCircles);
   static bool CircleFit(double *x, double *y, int N, double *pxc, double *pyc, double *pr,
                         double *pe);
-  static void ComputeCirclePoints(double xc, double yc, double r, double *px, double *py,
-                                  int *noPoints);
-  static void sortCircle(Circle *circles, int noCircles);
+  static void ComputeCirclePoints(double xc, double yc, double r, std::vector<double> &px, std::vector<double> &py,
+                                  int &noPoints);
 
   // ellipse utility functions
   static bool EllipseFit(double *x, double *y, int noPoints, EllipseEquation *pResult,
@@ -321,7 +320,7 @@ class EDCircles : public EDPF
   static double ComputeEllipseCenterAndAxisLengths(EllipseEquation *eq, double *pxc, double *pyc,
                                                    double *pmajorAxisLength,
                                                    double *pminorAxisLength);
-  static void ComputeEllipsePoints(double *pvec, double *px, double *py, int noPoints);
+  static void ComputeEllipsePoints(double *pvec, std::vector<double> &px, std::vector<double> &py, int noPoints);
 
   // arc utility functions
   static void joinLastTwoArcs(MyArc *arcs, int &noArcs);

--- a/EDColor.cpp
+++ b/EDColor.cpp
@@ -314,8 +314,7 @@ void EDColor::smoothChannel(uchar *src, uchar *smooth, double sigma)
 void EDColor::validateEdgeSegments()
 {
   int maxGradValue = MAX_GRAD_VALUE;
-  H = new double[maxGradValue];
-  memset(H, 0, sizeof(double) * maxGradValue);
+  H.resize(maxGradValue, 0);
 
   memset(edgeImg, 0, width * height);  // clear edge image
 
@@ -323,8 +322,7 @@ void EDColor::validateEdgeSegments()
   gradImg.clear();
   gradImg.resize(width * height, 0);
 
-  int *grads = new int[maxGradValue];
-  memset(grads, 0, sizeof(int) * maxGradValue);
+  std::vector<int> grads(maxGradValue, 0);
 
   for (int i = 1; i < height - 1; i++)
   {
@@ -389,10 +387,6 @@ void EDColor::validateEdgeSegments()
   {
     testSegment(i, 0, segments[i].size() - 1);
   }  // end-for
-
-  // clear space
-  delete[] H;
-  delete[] grads;
 }
 
 //----------------------------------------------------------------------------------

--- a/EDColor.cpp
+++ b/EDColor.cpp
@@ -59,7 +59,8 @@ EDColor::EDColor(Mat srcImage, int gradThresh, int anchor_thresh, double sigma,
   if (validateSegments)
   {
     // Get Edge Image using ED
-    ED edgeObj = ED(&gradImg[0], &dirImg[0], width, height, gradThresh, anchor_thresh, 1, 10, false);
+    ED edgeObj =
+        ED(&gradImg[0], &dirImg[0], width, height, gradThresh, anchor_thresh, 1, 10, false);
     segments = edgeObj.getSegments();
     edgeImage = edgeObj.getEdgeImage();
 

--- a/EDColor.cpp
+++ b/EDColor.cpp
@@ -31,26 +31,26 @@ EDColor::EDColor(Mat srcImage, int gradThresh, int anchor_thresh, double sigma,
   width = srcImage.cols;
 
   // Allocate space for L*a*b color space
-  L_Img = new uchar[width * height];
-  a_Img = new uchar[width * height];
-  b_Img = new uchar[width * height];
+  L_Img.resize(width * height);
+  a_Img.resize(width * height);
+  b_Img.resize(width * height);
 
   // Convert RGB2Lab
   MyRGB2LabFast();
 
   // Allocate space for smooth channels
-  smooth_L = new uchar[width * height];
-  smooth_a = new uchar[width * height];
-  smooth_b = new uchar[width * height];
+  smooth_L.resize(width * height);
+  smooth_a.resize(width * height);
+  smooth_b.resize(width * height);
 
   // Smooth Channels
-  smoothChannel(L_Img, smooth_L, sigma);
-  smoothChannel(a_Img, smooth_a, sigma);
-  smoothChannel(b_Img, smooth_b, sigma);
+  smoothChannel(&L_Img[0], &smooth_L[0], sigma);
+  smoothChannel(&a_Img[0], &smooth_a[0], sigma);
+  smoothChannel(&b_Img[0], &smooth_b[0], sigma);
 
   // Allocate space for direction and gradient images
-  dirImg = new uchar[width * height];
-  gradImg = new short[width * height];
+  dirImg.resize(width * height);
+  gradImg.resize(width * height);
 
   // Compute Gradient & Edge Direction Maps
   ComputeGradientMapByDiZenzo();
@@ -59,14 +59,14 @@ EDColor::EDColor(Mat srcImage, int gradThresh, int anchor_thresh, double sigma,
   if (validateSegments)
   {
     // Get Edge Image using ED
-    ED edgeObj = ED(gradImg, dirImg, width, height, gradThresh, anchor_thresh, 1, 10, false);
+    ED edgeObj = ED(&gradImg[0], &dirImg[0], width, height, gradThresh, anchor_thresh, 1, 10, false);
     segments = edgeObj.getSegments();
     edgeImage = edgeObj.getEdgeImage();
 
     sigma /= 2.5;
-    smoothChannel(L_Img, smooth_L, sigma);
-    smoothChannel(a_Img, smooth_a, sigma);
-    smoothChannel(b_Img, smooth_b, sigma);
+    smoothChannel(&L_Img[0], &smooth_L[0], sigma);
+    smoothChannel(&a_Img[0], &smooth_a[0], sigma);
+    smoothChannel(&b_Img[0], &smooth_b[0], sigma);
 
     edgeImg = edgeImage.data;  // validation steps uses pointer to edgeImage
 
@@ -78,7 +78,7 @@ EDColor::EDColor(Mat srcImage, int gradThresh, int anchor_thresh, double sigma,
 
   else
   {
-    ED edgeObj = ED(gradImg, dirImg, width, height, gradThresh, anchor_thresh);
+    ED edgeObj = ED(&gradImg[0], &dirImg[0], width, height, gradThresh, anchor_thresh);
     segments = edgeObj.getSegments();
     edgeImage = edgeObj.getEdgeImage();
     segmentNo = edgeObj.getSegmentNo();
@@ -86,18 +86,6 @@ EDColor::EDColor(Mat srcImage, int gradThresh, int anchor_thresh, double sigma,
 
   // Fix 1 pixel errors in the edge map
   fixEdgeSegments(segments, 1);
-
-  // clean space
-  delete[] L_Img;
-  delete[] a_Img;
-  delete[] b_Img;
-
-  delete[] smooth_L;
-  delete[] smooth_a;
-  delete[] smooth_b;
-
-  delete[] gradImg;
-  delete[] dirImg;
 }
 
 cv::Mat EDColor::getEdgeImage() { return edgeImage; }
@@ -120,9 +108,9 @@ void EDColor::MyRGB2LabFast()
   double x, y, z;
 
   // Space for temp. allocation
-  double *L = new double[width * height];
-  double *a = new double[width * height];
-  double *b = new double[width * height];
+  std::vector<double> L(width * height);
+  std::vector<double> a(width * height);
+  std::vector<double> b(width * height);
 
   for (int i = 0; i < width * height; i++)
   {
@@ -211,16 +199,12 @@ void EDColor::MyRGB2LabFast()
   {
     b_Img[i] = (unsigned char)((b[i] - min) * scale);
   }
-
-  // clean space
-  delete[] L;
-  delete[] a;
-  delete[] b;
 }
 
 void EDColor::ComputeGradientMapByDiZenzo()
 {
-  memset(gradImg, 0, sizeof(short) * width * height);
+  gradImg.clear();
+  gradImg.resize(width * height, 0);
 
   int max = 0;
 
@@ -335,7 +319,8 @@ void EDColor::validateEdgeSegments()
   memset(edgeImg, 0, width * height);  // clear edge image
 
   // Compute the gradient
-  memset(gradImg, 0, sizeof(short) * width * height);  // reset gradient Image pixels to zero
+  gradImg.clear();
+  gradImg.resize(width * height, 0);
 
   int *grads = new int[maxGradValue];
   memset(grads, 0, sizeof(int) * maxGradValue);
@@ -379,7 +364,7 @@ void EDColor::validateEdgeSegments()
     }  // end-for
   }    // end-for
 
-  Mat gradImage = Mat(height, width, CV_16SC1, gradImg);
+  Mat gradImage = Mat(height, width, CV_16SC1, &gradImg[0]);
   imwrite("newGrad.pgm", gradImage);
 
   // Compute probability function H

--- a/EDColor.h
+++ b/EDColor.h
@@ -87,7 +87,7 @@ class EDColor
   int height;
 
   double divForTestSegment;
-  double *H;
+  std::vector<double> H;
   int np;
   int segmentNo;
 

--- a/EDColor.h
+++ b/EDColor.h
@@ -65,16 +65,16 @@ class EDColor
   cv::Mat inputImage;
 
  private:
-  uchar *L_Img;
-  uchar *a_Img;
-  uchar *b_Img;
+  std::vector<uchar> L_Img;
+  std::vector<uchar> a_Img;
+  std::vector<uchar> b_Img;
 
-  uchar *smooth_L;
-  uchar *smooth_a;
-  uchar *smooth_b;
+  std::vector<uchar> smooth_L;
+  std::vector<uchar> smooth_a;
+  std::vector<uchar> smooth_b;
 
-  uchar *dirImg;
-  short *gradImg;
+  std::vector<uchar> dirImg;
+  std::vector<short> gradImg;
 
   cv::Mat edgeImage;
   uchar *edgeImg;

--- a/EDLines.cpp
+++ b/EDLines.cpp
@@ -87,7 +87,7 @@ EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
   // Temporary buffers used during line fitting
   std::vector<double> x((width + height) * 8, 0);
   std::vector<double> y((width + height) * 8, 0);
-  
+
   linesNo = 0;
 
   // Use the whole segment
@@ -1038,8 +1038,8 @@ void EDLines::UpdateLineParameters(LineSegment *ls)
   }    // end-else
 }
 
-void EDLines::EnumerateRectPoints(double sx, double sy, double ex, double ey, std::vector<int> &ptsx,
-                                  std::vector<int> &ptsy, int *pNoPoints)
+void EDLines::EnumerateRectPoints(double sx, double sy, double ex, double ey,
+                                  std::vector<int> &ptsx, std::vector<int> &ptsy, int *pNoPoints)
 {
   double vxTmp[4], vyTmp[4];
   double vx[4], vy[4];

--- a/EDLines.cpp
+++ b/EDLines.cpp
@@ -21,8 +21,8 @@ EDLines::EDLines(Mat srcImage, double _line_error, int _min_line_len,
     min_line_len = 9;
 
   // Temporary buffers used during line fitting
-  double *x = new double[(width + height) * 8];
-  double *y = new double[(width + height) * 8];
+  std::vector<double> x((width + height) * 8, 0);
+  std::vector<double> y((width + height) * 8, 0);
 
   linesNo = 0;
 
@@ -36,7 +36,7 @@ EDLines::EDLines(Mat srcImage, double _line_error, int _min_line_len,
       x[k] = segment[k].x;
       y[k] = segment[k].y;
     }
-    SplitSegment2Lines(x, y, segment.size(), segmentNumber);
+    SplitSegment2Lines(&x[0], &y[0], segment.size(), segmentNumber);
   }
 
   /*----------- JOIN COLLINEAR LINES ----------------*/
@@ -51,7 +51,7 @@ EDLines::EDLines(Mat srcImage, double _line_error, int _min_line_len,
   double logNT = 2.0 * (log10((double)width) + log10((double)height));
 
   int lutSize = (width + height) / 8;
-  nfa = new NFALUT(lutSize, prob, logNT);  // create look up table
+  nfa = std::make_shared<NFALUT>(lutSize, prob, logNT);  // create look up table
 
   ValidateLineSegments();
 
@@ -67,10 +67,6 @@ EDLines::EDLines(Mat srcImage, double _line_error, int _min_line_len,
 
     linePoints.push_back(LS(start, end));
   }  // end-for
-
-  delete[] x;
-  delete[] y;
-  delete nfa;
 }
 
 EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
@@ -89,9 +85,9 @@ EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
     min_line_len = 9;
 
   // Temporary buffers used during line fitting
-  double *x = new double[(width + height) * 8];
-  double *y = new double[(width + height) * 8];
-
+  std::vector<double> x((width + height) * 8, 0);
+  std::vector<double> y((width + height) * 8, 0);
+  
   linesNo = 0;
 
   // Use the whole segment
@@ -104,7 +100,7 @@ EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
       x[k] = segment[k].x;
       y[k] = segment[k].y;
     }
-    SplitSegment2Lines(x, y, segment.size(), segmentNumber);
+    SplitSegment2Lines(&x[0], &y[0], segment.size(), segmentNumber);
   }
 
   /*----------- JOIN COLLINEAR LINES ----------------*/
@@ -119,7 +115,7 @@ EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
   double logNT = 2.0 * (log10((double)width) + log10((double)height));
 
   int lutSize = (width + height) / 8;
-  nfa = new NFALUT(lutSize, prob, logNT);  // create look up table
+  nfa = std::make_shared<NFALUT>(lutSize, prob, logNT);  // create look up table
 
   ValidateLineSegments();
 
@@ -135,10 +131,6 @@ EDLines::EDLines(ED obj, double _line_error, int _min_line_len,
 
     linePoints.push_back(LS(start, end));
   }  // end-for
-
-  delete[] x;
-  delete[] y;
-  delete nfa;
 }
 
 EDLines::EDLines(EDColor obj, double _line_error, int _min_line_len,
@@ -157,8 +149,8 @@ EDLines::EDLines(EDColor obj, double _line_error, int _min_line_len,
     min_line_len = 9;
 
   // Temporary buffers used during line fitting
-  double *x = new double[(width + height) * 8];
-  double *y = new double[(width + height) * 8];
+  std::vector<double> x((width + height) * 8, 0);
+  std::vector<double> y((width + height) * 8, 0);
 
   linesNo = 0;
 
@@ -172,7 +164,7 @@ EDLines::EDLines(EDColor obj, double _line_error, int _min_line_len,
       x[k] = segment[k].x;
       y[k] = segment[k].y;
     }
-    SplitSegment2Lines(x, y, segment.size(), segmentNumber);
+    SplitSegment2Lines(&x[0], &y[0], segment.size(), segmentNumber);
   }
 
   /*----------- JOIN COLLINEAR LINES ----------------*/
@@ -187,7 +179,7 @@ EDLines::EDLines(EDColor obj, double _line_error, int _min_line_len,
   double logNT = 2.0 * (log10((double)width) + log10((double)height));
 
   int lutSize = (width + height) / 8;
-  nfa = new NFALUT(lutSize, prob, logNT);  // create look up table
+  nfa = std::make_shared<NFALUT>(lutSize, prob, logNT);  // create look up table
 
   // Since edge segments are validated in ed color,
   // Validation is not performed again in line segment detection
@@ -206,10 +198,6 @@ EDLines::EDLines(EDColor obj, double _line_error, int _min_line_len,
 
     linePoints.push_back(LS(start, end));
   }  // end-for
-
-  delete[] x;
-  delete[] y;
-  delete nfa;
 }
 
 EDLines::EDLines()
@@ -331,7 +319,7 @@ void EDLines::SplitSegment2Lines(double *x, double *y, int noPixels, int segment
       if (goodPixelCount >= 2)
       {
         len += lastGoodIndex - startIndex + 1;
-        LineFit(x, y, len, lastA, lastB, lastInvert);  // faster LineFit
+        LineFit(&x[0], &y[0], len, lastA, lastB, lastInvert);  // faster LineFit
         index = lastGoodIndex + 1;
       }  // end-if
 
@@ -417,8 +405,8 @@ void EDLines::JoinCollinearLines()
 
 void EDLines::ValidateLineSegments()
 {
-  int *x = new int[(width + height) * 4];
-  int *y = new int[(width + height) * 4];
+  std::vector<int> x((width + height) * 4, 0);
+  std::vector<int> y((width + height) * 4, 0);
 
   int noValidLines = 0;
   int eraseOffset = 0;
@@ -518,12 +506,9 @@ void EDLines::ValidateLineSegments()
   }    // end-for
 
   linesNo = noValidLines;
-
-  delete x;
-  delete y;
 }
 
-bool EDLines::ValidateLineSegmentRect(int *x, int *y, LineSegment *ls)
+bool EDLines::ValidateLineSegmentRect(std::vector<int> &x, std::vector<int> &y, LineSegment *ls)
 {
   // Compute Line's angle
   double lineAngle;
@@ -1053,8 +1038,8 @@ void EDLines::UpdateLineParameters(LineSegment *ls)
   }    // end-else
 }
 
-void EDLines::EnumerateRectPoints(double sx, double sy, double ex, double ey, int ptsx[],
-                                  int ptsy[], int *pNoPoints)
+void EDLines::EnumerateRectPoints(double sx, double sy, double ex, double ey, std::vector<int> &ptsx,
+                                  std::vector<int> &ptsy, int *pNoPoints)
 {
   double vxTmp[4], vyTmp[4];
   double vx[4], vy[4];

--- a/EDLines.h
+++ b/EDLines.h
@@ -97,14 +97,14 @@ class EDLines : public ED
   double max_distance_between_two_lines;
   double max_error;
   double prec;
-  NFALUT *nfa;
+  std::shared_ptr<NFALUT> nfa;
 
   int ComputeMinLineLength();
   void SplitSegment2Lines(double *x, double *y, int noPixels, int segmentNo);
   void JoinCollinearLines();
 
   void ValidateLineSegments();
-  bool ValidateLineSegmentRect(int *x, int *y, LineSegment *ls);
+  bool ValidateLineSegmentRect(std::vector<int> &x, std::vector<int> &y, LineSegment *ls);
   bool TryToJoinTwoLineSegments(LineSegment *ls1, LineSegment *ls2, int changeIndex);
 
   static double ComputeMinDistance(double x1, double y1, double a, double b, int invert);
@@ -115,8 +115,8 @@ class EDLines : public ED
                       int &invert);
   static double ComputeMinDistanceBetweenTwoLines(LineSegment *ls1, LineSegment *ls2, int *pwhich);
   static void UpdateLineParameters(LineSegment *ls);
-  static void EnumerateRectPoints(double sx, double sy, double ex, double ey, int ptsx[],
-                                  int ptsy[], int *pNoPoints);
+  static void EnumerateRectPoints(double sx, double sy, double ex, double ey, std::vector<int> &ptsx,
+                                  std::vector<int> &ptsy, int *pNoPoints);
 
   // Utility math functions
 };

--- a/EDLines.h
+++ b/EDLines.h
@@ -115,8 +115,8 @@ class EDLines : public ED
                       int &invert);
   static double ComputeMinDistanceBetweenTwoLines(LineSegment *ls1, LineSegment *ls2, int *pwhich);
   static void UpdateLineParameters(LineSegment *ls);
-  static void EnumerateRectPoints(double sx, double sy, double ex, double ey, std::vector<int> &ptsx,
-                                  std::vector<int> &ptsy, int *pNoPoints);
+  static void EnumerateRectPoints(double sx, double sy, double ex, double ey,
+                                  std::vector<int> &ptsx, std::vector<int> &ptsy, int *pNoPoints);
 
   // Utility math functions
 };

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -28,10 +28,9 @@ void EDPF::validateEdgeSegments()
   divForTestSegment = 2.25;            // Some magic number :-)
   memset(edgeImg, 0, width * height);  // clear edge image
 
-  H = new double[MAX_GRAD_VALUE];
-  memset(H, 0, sizeof(double) * MAX_GRAD_VALUE);
+  H.resize(MAX_GRAD_VALUE, 0);
 
-  gradImg = ComputePrewitt3x3();
+  ComputePrewitt3x3(gradImg);
 
   // Compute np: # of segment pieces
 #if 1
@@ -62,19 +61,14 @@ void EDPF::validateEdgeSegments()
   }  // end-for
 
   ExtractNewSegments();
-
-  // clean space
-  delete[] H;
-  delete[] gradImg;
 }
 
-short *EDPF::ComputePrewitt3x3()
+void EDPF::ComputePrewitt3x3(std::vector<short> &img)
 {
-  short *gradImg = new short[width * height];
-  memset(gradImg, 0, sizeof(short) * width * height);
+  img.clear();
+  img.resize(width * height, 0);
 
-  int *grads = new int[MAX_GRAD_VALUE];
-  memset(grads, 0, sizeof(int) * MAX_GRAD_VALUE);
+  std::vector<int> grads(MAX_GRAD_VALUE, 0);
 
   for (int i = 1; i < height - 1; i++)
   {
@@ -101,7 +95,7 @@ short *EDPF::ComputePrewitt3x3()
 
       int g = gx + gy;
 
-      gradImg[i * width + j] = g;
+      img[i * width + j] = g;
       grads[g]++;
     }  // end-for
   }    // end-for
@@ -112,9 +106,6 @@ short *EDPF::ComputePrewitt3x3()
   for (int i = MAX_GRAD_VALUE - 1; i > 0; i--) grads[i - 1] += grads[i];
 
   for (int i = 0; i < MAX_GRAD_VALUE; i++) H[i] = (double)grads[i] / ((double)size);
-
-  delete[] grads;
-  return gradImg;
 }
 
 //----------------------------------------------------------------------------------

--- a/EDPF.h
+++ b/EDPF.h
@@ -31,12 +31,12 @@ class EDPF : public ED
 
  private:
   double divForTestSegment;
-  double *H;
+  std::vector<double> H;
   int np;
-  short *gradImg;
+  std::vector<short> gradImg;
 
   void validateEdgeSegments();
-  short *ComputePrewitt3x3();  // differs from base class's prewit function (calculates H)
+  void ComputePrewitt3x3(std::vector<short> &img);  // differs from base class's prewit function (calculates H)
   void TestSegment(int i, int index1, int index2);
   void ExtractNewSegments();
   double NFA(double prob, int len);

--- a/EDPF.h
+++ b/EDPF.h
@@ -36,7 +36,8 @@ class EDPF : public ED
   std::vector<short> gradImg;
 
   void validateEdgeSegments();
-  void ComputePrewitt3x3(std::vector<short> &img);  // differs from base class's prewit function (calculates H)
+  void ComputePrewitt3x3(
+      std::vector<short> &img);  // differs from base class's prewit function (calculates H)
   void TestSegment(int i, int index1, int index2);
   void ExtractNewSegments();
   double NFA(double prob, int len);

--- a/NFA.cpp
+++ b/NFA.cpp
@@ -5,7 +5,7 @@
 NFALUT::NFALUT(int size, double _prob, double _logNT)
 {
   LUTSize = size;
-  LUT = new int[LUTSize];
+  LUT.resize(size, 0);
 
   prob = _prob;
   logNT = _logNT;
@@ -32,7 +32,7 @@ NFALUT::NFALUT(int size, double _prob, double _logNT)
   }  // end-for
 }
 
-NFALUT::~NFALUT() { delete[] LUT; }
+NFALUT::~NFALUT() {}
 
 bool NFALUT::checkValidationByNFA(int n, int k)
 {

--- a/NFA.h
+++ b/NFA.h
@@ -1,6 +1,8 @@
 #ifndef _NFA_
 #define _NFA_
 
+#include <vector>
+
 #define TABSIZE 100000
 
 //----------------------------------------------
@@ -31,7 +33,7 @@ class NFALUT
   NFALUT(int size, double _prob, double _logNT);
   ~NFALUT();
 
-  int *LUT;  // look up table
+  std::vector<int> LUT;  // look up table
   int LUTSize;
 
   double prob;


### PR DESCRIPTION
- `T*` / `T[]` -> `std::vector<T>`
- `T**` -> `std::vector<std::vector<T>>`

Before this change, the result image of i.e. EDPF differs among every run even from the same input image, which makes difficult to create golden tests.
With this change, the result should be always the same from one input image.   

@AkiraShibata18 Maybe you also use this library for your current/former projects. Can you check if the change does not break anything?