### PR TITLE
Fix gradImg re-definition

### DIFF
--- a/ED.cpp
+++ b/ED.cpp
@@ -310,6 +310,8 @@ void ED::ComputeGradient()
   gradImage.col(gradImage.cols - 1).setTo(gradThresh - 1);
   gradImage.row(0).setTo(gradThresh - 1);
   gradImage.row(gradImage.rows - 1).setTo(gradThresh - 1);
+  gradImg = (short *)gradImage.data;
+
   dirImage = cv::Mat::zeros(gradImage.rows, gradImage.cols, CV_8UC1);
   const cv::Mat maskThresh = gradImage >= gradThresh;
   cv::Mat maskVertical, maskHorizontal;

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -72,16 +72,14 @@ void EDPF::ComputePrewitt3x3()
   gradImage.col(gradImage.cols - 1).setTo(0);
   gradImage.row(0).setTo(0);
   gradImage.row(gradImage.rows - 1).setTo(0);
+  gradImg = (short *)gradImage.data;
 
   double max_grad_value = static_cast<double>(MAX_GRAD_VALUE);
   cv::minMaxLoc(gradImage, nullptr, &max_grad_value);
   std::vector<int> grads(static_cast<int>(max_grad_value) + 1, 0);
-  for (int i = 0; i < gradImage.cols; ++i)
+  for (int i = 0; i < gradImage.total(); ++i)
   {
-    for (int j = 0; j < gradImage.rows; ++j)
-    {
-      grads[gradImage.at<int>(i, j)]++;
-    }
+    grads[gradImg[i]]++;
   }
 
   // Compute probability function H

--- a/EDPF.h
+++ b/EDPF.h
@@ -33,7 +33,6 @@ class EDPF : public ED
   double divForTestSegment;
   std::vector<double> H;
   int np;
-  std::vector<short> gradImg;
 
   void validateEdgeSegments();
   void ComputePrewitt3x3();  // differs from base class's prewit function (calculates H)


### PR DESCRIPTION
From the comment on the last PR https://github.com/GITAI/ED_Lib/pull/5#discussion_r1045164487,
I found the member variable `ED::gradImg` is re-defined by `EDPF::gradImg`, which causes confusion in code.
This PR fixes the issue by removing the definition from `EDPF`