### PR TITLE
Reuse internal data as much as possible

### DIFF
--- a/ED.cpp
+++ b/ED.cpp
@@ -346,6 +346,7 @@ void ED::ComputeGradient()
   gradImage.col(gradImage.cols - 1).setTo(gradThresh - 1);
   gradImage.row(0).setTo(gradThresh - 1);
   gradImage.row(gradImage.rows - 1).setTo(gradThresh - 1);
+  gradImg = (short *)gradImage.data;
   dirImage = cv::Mat::zeros(gradImage.rows, gradImage.cols, CV_8UC1);
   const cv::Mat maskThresh = gradImage >= gradThresh;
   cv::Mat maskVertical, maskHorizontal;

--- a/ED.cpp
+++ b/ED.cpp
@@ -418,7 +418,7 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
   int totalPixels = 0;
   int segmentNos = 0;
 
-  for (int k = anchorPoints.size() - 1; k >= 0; k--)
+  for (int k = static_cast<int>(anchorPoints.size()) - 1; k >= 0; k--)
   {
     int pixelOffset = A[k];
 

--- a/ED.cpp
+++ b/ED.cpp
@@ -26,10 +26,10 @@ void ED::prealloc(const int _width, const int _height)
   dirImage = Mat(height, width, CV_8UC1);
   gradImage = Mat(height, width, CV_16SC1);  // gradImage contains short values
 
-  chainNos.reserve((width + height) * 8);
-  pixels.reserve(width * height);
-  stack.reserve(width * height);
-  chains.reserve(width * height);
+  chainNos.resize((width + height) * 8);
+  pixels.resize(width * height);
+  stack.resize(width * height);
+  chains.resize(width * height);
 }
 
 void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh, int _scanInterval,
@@ -99,6 +99,7 @@ ED::ED(const ED &cpyObj)
 {
   height = cpyObj.height;
   width = cpyObj.width;
+  prealloc(width, height);
 
   srcImage = cpyObj.srcImage.clone();
 
@@ -132,6 +133,8 @@ ED::ED(short *_gradImg, uchar *_dirImg, int _width, int _height, int _gradThresh
 {
   height = _height;
   width = _width;
+
+  prealloc(width, height);
 
   gradThresh = _gradThresh;
   anchorThresh = _anchorThresh;
@@ -231,6 +234,7 @@ ED::ED(EDColor &obj)
 {
   width = obj.getWidth();
   height = obj.getHeight();
+  prealloc(width, height);
   segmentPoints = obj.getSegments();
 }
 
@@ -449,10 +453,6 @@ void ED::ComputeAnchorPoints()
 void ED::JoinAnchorPointsUsingSortedAnchors()
 {
   const auto start_tick = getTickCount();
-  chainNos.resize((width + height) * 8);
-  pixels.resize(width * height);
-  stack.resize(width * height);
-  chains.resize(width * height);
   segmentPoints.clear();
   segmentPoints.push_back(vector<Point>());
   const auto alloc_tick = getTickCount();
@@ -1109,11 +1109,6 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
   // pop back last segment from vector
   // because of one preallocation in the beginning, it will always empty
   segmentPoints.pop_back();
-
-  chainNos.clear();
-  pixels.clear();
-  stack.clear();
-  chains.clear();
 }
 
 void ED::sortAnchorsByGradValue()

--- a/ED.h
+++ b/ED.h
@@ -72,7 +72,8 @@ class ED
     double join_anchor_points_alloc;
     double sort_anchors_by_grad_value;
   };
-  
+
+  ED(const int _width, const int _height);
   ED(cv::Mat _srcImage, GradientOperator _op = PREWITT_OPERATOR, int _gradThresh = 20,
      int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10, double _sigma = 1.0,
      bool _sumFlag = true);
@@ -81,6 +82,15 @@ class ED
      int _scanInterval = 1, int _minPathLen = 10, bool selectStableAnchors = true);
   ED(EDColor &cpyObj);
   ED();
+
+  void prealloc(const int _width, const int _height);
+
+  void process(cv::Mat _srcImage, GradientOperator _op = PREWITT_OPERATOR, int _gradThresh = 20,
+     int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10, double _sigma = 1.0,
+     bool _sumFlag = true);
+  int getWidth() const { return width; }
+  int getHeight() const { return height; }
+  
 
   cv::Mat getEdgeImage();
   cv::Mat getAnchorImage();
@@ -138,6 +148,12 @@ class ED
   int anchorThresh;     // anchor point threshold
   int scanInterval;
   bool sumFlag;
+
+  // cached data used in JoinAnchorPointsUsingSortedAnchors
+  std::vector<int> chainNos;
+  std::vector<cv::Point> pixels;
+  std::vector<StackNode> stack;
+  std::vector<Chain> chains;
 };
 
 #endif

--- a/ED.h
+++ b/ED.h
@@ -60,6 +60,19 @@ struct Chain
 class ED
 {
  public:
+
+  struct Profile
+  {
+    double initialize;
+    double gaussian_blur;
+    double compute_gradient;
+    double compute_anchor_points;
+    double join_anchor_points_using_sorted_anchors;
+    // in JoinAnchorPointsUsingSortedAnchors method
+    double join_anchor_points_alloc;
+    double sort_anchors_by_grad_value;
+  };
+  
   ED(cv::Mat _srcImage, GradientOperator _op = PREWITT_OPERATOR, int _gradThresh = 20,
      int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10, double _sigma = 1.0,
      bool _sumFlag = true);
@@ -83,6 +96,8 @@ class ED
 
   cv::Mat drawParticularSegments(std::vector<int> list);
 
+  Profile getLastEDProfile() const;
+
  protected:
   int width;   // width of source image
   int height;  // height of source image
@@ -95,6 +110,7 @@ class ED
   int segmentNos;
   int minPathLen;
   cv::Mat srcImage;
+  Profile lastEDProfile;
 
  private:
   void ComputeGradient();

--- a/ED.h
+++ b/ED.h
@@ -96,6 +96,7 @@ class ED
   cv::Mat getAnchorImage();
   cv::Mat getSmoothImage();
   cv::Mat getGradImage();
+  cv::Mat getDirImage();
 
   int getSegmentNo();
   int getAnchorNo();
@@ -117,7 +118,6 @@ class ED
   cv::Mat smoothImage;
   uchar *edgeImg;    // pointer to edge image data
   uchar *smoothImg;  // pointer to smoothed image data
-  int segmentNos;
   int minPathLen;
   cv::Mat srcImage;
   Profile lastEDProfile;
@@ -132,9 +132,7 @@ class ED
   static int LongestChain(std::vector<Chain> &chains, int root);
   static int RetrieveChainNos(std::vector<Chain> &chains, int root, std::vector<int> &chainNos);
 
-  int anchorNos;
   std::vector<cv::Point> anchorPoints;
-  std::vector<cv::Point> edgePoints;
 
   cv::Mat edgeImage;
   cv::Mat dirImage;

--- a/EDCircles.cpp
+++ b/EDCircles.cpp
@@ -16,14 +16,14 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines.resize(segmentNos + 1, 0);
+  segmentStartLines.resize(getSegmentNo() + 1, 0);
 
   bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
 
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     // Make note of the starting line number for this segment
     segmentStartLines[i] = lines.size();
@@ -106,14 +106,14 @@ EDCircles::EDCircles(Mat srcImage) : EDPF(srcImage)
     EDLines::SplitSegment2Lines(x, y, noPixels, i, lines);
   }
 
-  segmentStartLines[segmentNos] = lines.size();
+  segmentStartLines[getSegmentNo()] = lines.size();
 
   // ------------------------------- DETECT ARCS ---------------------------------
 
   info.resize(lines.size());
 
   // Compute the angle information for each line segment
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     for (int j = segmentStartLines[i]; j < segmentStartLines[i + 1]; j++)
     {
@@ -241,14 +241,14 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines.resize(segmentNos + 1, 0);
+  segmentStartLines.resize(getSegmentNo() + 1, 0);
 
   bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
 
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     // Make note of the starting line number for this segment
     segmentStartLines[i] = lines.size();
@@ -331,13 +331,13 @@ EDCircles::EDCircles(ED obj) : EDPF(obj)
     EDLines::SplitSegment2Lines(x, y, noPixels, i, lines);
   }
 
-  segmentStartLines[segmentNos] = lines.size();
+  segmentStartLines[getSegmentNo()] = lines.size();
 
   // ------------------------------- DETECT ARCS ---------------------------------
   info.resize(lines.size());
 
   // Compute the angle information for each line segment
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     for (int j = segmentStartLines[i]; j < segmentStartLines[i + 1]; j++)
     {
@@ -465,14 +465,14 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
   for (int i = 0; i < segmentPoints.size(); i++) bufferSize += segmentPoints[i].size();
 
   // Compute the starting line number for each segment
-  segmentStartLines.resize(segmentNos + 1, 0);
+  segmentStartLines.resize(getSegmentNo() + 1, 0);
 
   bm = std::make_shared<BufferManager>(bufferSize * 8);
   vector<LineSegment> lines;
 
 #define CIRCLE_MIN_LINE_LEN 6
 
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     // Make note of the starting line number for this segment
     segmentStartLines[i] = lines.size();
@@ -555,14 +555,14 @@ EDCircles::EDCircles(EDColor obj) : EDPF(obj)
     EDLines::SplitSegment2Lines(x, y, noPixels, i, lines);
   }
 
-  segmentStartLines[segmentNos] = lines.size();
+  segmentStartLines[getSegmentNo()] = lines.size();
 
   // ------------------------------- DETECT ARCS ---------------------------------
 
   info.resize(lines.size());
 
   // Compute the angle information for each line segment
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     for (int j = segmentStartLines[i]; j < segmentStartLines[i + 1]; j++)
     {
@@ -800,7 +800,7 @@ void EDCircles::DetectArcs(vector<LineSegment> lines)
       MAX_ANGLE = PI / 1.9;  // 95 degrees
                              //    if (iter == 2) MAX_ANGLE = PI/2.25;  // 80 degrees
 
-    for (int curSegmentNo = 0; curSegmentNo < segmentNos; curSegmentNo++)
+    for (int curSegmentNo = 0; curSegmentNo < getSegmentNo(); curSegmentNo++)
     {
       int firstLine = segmentStartLines[curSegmentNo];
       int stopLine = segmentStartLines[curSegmentNo + 1];

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -78,7 +78,7 @@ void EDPF::validateEdgeSegments()
   // Does this underestimate the number of pieces of edge segments?
   // What's the correct value?
   np = 0;
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     int len = segmentPoints[i].size();
     np += (len * (len - 1)) / 2;
@@ -88,7 +88,7 @@ void EDPF::validateEdgeSegments()
 #elif 0
   // This definitely overestimates the number of pieces of edge segments
   int np = 0;
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     np += segmentPoints[i].size();
   }  // end-for
@@ -96,7 +96,7 @@ void EDPF::validateEdgeSegments()
 #endif
 
   // Validate segments
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     TestSegment(i, 0, segmentPoints[i].size() - 1);
   }  // end-for
@@ -226,11 +226,11 @@ void EDPF::TestSegment(int i, int index1, int index2)
 //
 void EDPF::ExtractNewSegments()
 {
-  // vector<Point> *segments = &segmentPoints[segmentNos];
+  // vector<Point> *segments = &segmentPoints[getSegmentNo()];
   vector<vector<Point> > validSegments;
   int noSegments = 0;
 
-  for (int i = 0; i < segmentNos; i++)
+  for (int i = 0; i < getSegmentNo(); i++)
   {
     int start = 0;
     while (start < segmentPoints[i].size())
@@ -272,8 +272,6 @@ void EDPF::ExtractNewSegments()
 
   // Copy to ed
   segmentPoints = validSegments;
-
-  segmentNos = noSegments;
 }
 
 //---------------------------------------------------------------------------

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -42,7 +42,6 @@ EDPF::EDPF(EDColor obj) : ED(obj) {}
 void EDPF::prealloc()
 {
   H.reserve(MAX_GRAD_VALUE);
-  gradImg.reserve(width * height);
 }
 
 void EDPF::process(cv::Mat _srcImage)
@@ -110,16 +109,14 @@ void EDPF::ComputePrewitt3x3()
   gradImage.col(gradImage.cols - 1).setTo(0);
   gradImage.row(0).setTo(0);
   gradImage.row(gradImage.rows - 1).setTo(0);
+  gradImg = (short *)gradImage.data;
 
   double max_grad_value = static_cast<double>(MAX_GRAD_VALUE);
   cv::minMaxLoc(gradImage, nullptr, &max_grad_value);
   std::vector<int> grads(static_cast<int>(max_grad_value) + 1, 0);
-  for (int i = 0; i < gradImage.cols; ++i)
+  for (int i = 0; i < gradImage.total(); ++i)
   {
-    for (int j = 0; j < gradImage.rows; ++j)
-    {
-      grads[gradImage.at<int>(i, j)]++;
-    }
+    grads[gradImg[i]]++;
   }
 
   // Compute probability function H

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -6,10 +6,15 @@ using namespace std;
 EDPF::EDPF(Mat srcImage) : ED(srcImage, PREWITT_OPERATOR, 11, 3)
 {
   // Validate Edge Segments
+  const auto start_tick = getTickCount();
   sigma /= 2.5;
   GaussianBlur(srcImage, smoothImage, Size(), sigma);  // calculate kernel from sigma
+  const auto gaussian_blur_tick = getTickCount();
+  lastEDPFProfile.gaussian_blur = (gaussian_blur_tick - start_tick) / getTickFrequency();
 
   validateEdgeSegments();
+  const auto validate_edge_segments_tick = getTickCount();
+  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
 }
 
 EDPF::EDPF(ED obj) : ED(obj)
@@ -245,3 +250,5 @@ double EDPF::NFA(double prob, int len)
 
   return nfa;
 }
+
+EDPF::Profile EDPF::getLastEDPFProfile() const { return lastEDPFProfile; }

--- a/EDPF.h
+++ b/EDPF.h
@@ -31,10 +31,14 @@ class EDPF : public ED
     double gaussian_blur;
     double validate_edge_segments;
   };
-  
+
+  EDPF(const int _width, const int _height);
   EDPF(cv::Mat srcImage);
   EDPF(ED obj);
   EDPF(EDColor obj);
+
+  void prealloc();
+  void process(cv::Mat _srcImage);
 
   Profile getLastEDPFProfile() const;
 

--- a/EDPF.h
+++ b/EDPF.h
@@ -25,15 +25,25 @@
 class EDPF : public ED
 {
  public:
+
+  struct Profile
+  {
+    double gaussian_blur;
+    double validate_edge_segments;
+  };
+  
   EDPF(cv::Mat srcImage);
   EDPF(ED obj);
   EDPF(EDColor obj);
+
+  Profile getLastEDPFProfile() const;
 
  private:
   double divForTestSegment;
   std::vector<double> H;
   int np;
   std::vector<short> gradImg;
+  Profile lastEDPFProfile;
 
   void validateEdgeSegments();
   void ComputePrewitt3x3(

--- a/EDPF.h
+++ b/EDPF.h
@@ -46,7 +46,6 @@ class EDPF : public ED
   double divForTestSegment;
   std::vector<double> H;
   int np;
-  std::vector<short> gradImg;
   Profile lastEDPFProfile;
 
   void validateEdgeSegments();


### PR DESCRIPTION
The existing implementation is designed for computing all operations in a constructor method and we cannot reuse the allocated internal data for processing next coming images.
What is done in this PR are:
- Moved the operations done in constructor to `process` method
- Extracted allocations to `prealloc` from `process`