### PR TITLE
Optimize EDPF

### DIFF
--- a/ED.cpp
+++ b/ED.cpp
@@ -353,8 +353,10 @@ void ED::ComputeGradient()
 
   dirImage.setTo(0);
   cv::compare(gradImage, gradThresh, maskThresh, cv::CMP_GE);
-  cv::bitwise_and(maskThresh, gxImage >= gyImage, maskVertical);
-  cv::bitwise_and(maskThresh, gxImage < gyImage, maskHorizontal);
+  cv::compare(gxImage, gyImage, maskImage, cv::CMP_GE);
+  cv::bitwise_and(maskThresh, maskImage, maskVertical);
+  cv::bitwise_not(maskImage, maskImage);
+  cv::bitwise_and(maskThresh, maskImage, maskHorizontal);
   dirImage.setTo(EDGE_VERTICAL, maskVertical);
   dirImage.setTo(EDGE_HORIZONTAL, maskHorizontal);
 }

--- a/ED.cpp
+++ b/ED.cpp
@@ -353,7 +353,7 @@ void ED::ComputeGradient()
   cv::absdiff(gyImage, cv::Scalar::all(0), gyImage);
   if (sumFlag)
   {
-    cv::add(cv::abs(gxImage), cv::abs(gyImage), gradImage);
+    cv::add(gxImage, gyImage, gradImage);
   }
   else
   {

--- a/ED.cpp
+++ b/ED.cpp
@@ -331,15 +331,18 @@ void ED::ComputeGradient()
 
   cv::filter2D(smoothImage, gxImageSigned, CV_16SC1, kernel.t(), anchor);
   cv::filter2D(smoothImage, gyImageSigned, CV_16SC1, kernel, anchor);
-  const cv::MatExpr gxImage = cv::abs(gxImageSigned);
-  const cv::MatExpr gyImage = cv::abs(gyImageSigned);
+  gxImage = cv::abs(gxImageSigned);
+  gyImage = cv::abs(gyImageSigned);
   if (sumFlag)
   {
     cv::add(gxImage, gyImage, gradImage);
   }
   else
   {
-    cv::add(gxImage.mul(gxImage), gyImage.mul(gyImage), gradImage);
+    // gxImageSigned and gyImageSigned is used as buffer for square
+    cv::multiply(gxImage, gxImage, gxImageSigned);
+    cv::multiply(gyImage, gyImage, gyImageSigned);
+    cv::add(gxImageSigned, gyImageSigned, gradImage);
     cv::sqrt(gradImage, gradImage);
   }
   gradImage.col(0).setTo(gradThresh - 1);

--- a/ED.cpp
+++ b/ED.cpp
@@ -5,13 +5,10 @@
 using namespace cv;
 using namespace std;
 
-ED::ED(const int _width, const int _height)
-{
-  prealloc(_width, _height);
-}
+ED::ED(const int _width, const int _height) { prealloc(_width, _height); }
 
 ED::ED(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh, int _scanInterval,
-            int _minPathLen, double _sigma, bool _sumFlag)
+       int _minPathLen, double _sigma, bool _sumFlag)
 {
   prealloc(_srcImage.cols, _srcImage.rows);
   process(_srcImage, _op, _gradThresh, _anchorThresh, _scanInterval, _minPathLen, _sigma, _sumFlag);
@@ -32,8 +29,8 @@ void ED::prealloc(const int _width, const int _height)
   chains.resize(width * height);
 }
 
-void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh, int _scanInterval,
-            int _minPathLen, double _sigma, bool _sumFlag)
+void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh,
+                 int _scanInterval, int _minPathLen, double _sigma, bool _sumFlag)
 {
   const auto start_tick = getTickCount();
   // Check parameters for sanity
@@ -58,7 +55,7 @@ void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anch
   srcImg = srcImage.data;
   const auto initialize_tick = getTickCount();
   lastEDProfile.initialize = (initialize_tick - start_tick) / getTickFrequency();
-  
+
   //// Detect Edges By Edge Drawing Algorithm  ////
 
   /*------------ SMOOTH THE IMAGE BY A GAUSSIAN KERNEL -------------------*/
@@ -79,18 +76,21 @@ void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anch
   /*------------ COMPUTE GRADIENT & EDGE DIRECTION MAPS -------------------*/
   ComputeGradient();
   const auto compute_gradient_tick = getTickCount();
-  lastEDProfile.compute_gradient = (compute_gradient_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDProfile.compute_gradient =
+      (compute_gradient_tick - gaussian_blur_tick) / getTickFrequency();
 
   /*------------ COMPUTE ANCHORS -------------------*/
   ComputeAnchorPoints();
   const auto compute_anchor_points_tick = getTickCount();
-  lastEDProfile.compute_anchor_points = (compute_anchor_points_tick - compute_gradient_tick) / getTickFrequency();
+  lastEDProfile.compute_anchor_points =
+      (compute_anchor_points_tick - compute_gradient_tick) / getTickFrequency();
 
   /*------------ JOIN ANCHORS -------------------*/
   JoinAnchorPointsUsingSortedAnchors();
   const auto join_anchor_points_using_sorted_anchors_tick = getTickCount();
   lastEDProfile.join_anchor_points_using_sorted_anchors =
-    (join_anchor_points_using_sorted_anchors_tick - compute_anchor_points_tick) / getTickFrequency();
+      (join_anchor_points_using_sorted_anchors_tick - compute_anchor_points_tick) /
+      getTickFrequency();
 }
 
 // This constructor for use of EDLines and EDCircle with ED given as constructor argument
@@ -308,39 +308,39 @@ void ED::ComputeGradient()
   cv::Point anchor;
   switch (op)
   {
-  case PREWITT_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
-    anchor = cv::Point(-1, -1);
-    break;
-  case SOBEL_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -1, -2, -1, 0, 0, 0, 1, 2, 1);
-    anchor = cv::Point(-1, -1);
-    break;
-  case SCHARR_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -3, -10, -3, 0, 0, 0, 3, 10, 3);
-    anchor = cv::Point(-1, -1);
-    break;
-  case LSD_OPERATOR:
-    kernel = (cv::Mat_<int>(2, 2) << -1, -1, 1, 1);
-    anchor = cv::Point(0, 0);
-    break;
-  default:
-    throw std::runtime_error("Invalid op");
-    break;
+    case PREWITT_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
+      anchor = cv::Point(-1, -1);
+      break;
+    case SOBEL_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -1, -2, -1, 0, 0, 0, 1, 2, 1);
+      anchor = cv::Point(-1, -1);
+      break;
+    case SCHARR_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -3, -10, -3, 0, 0, 0, 3, 10, 3);
+      anchor = cv::Point(-1, -1);
+      break;
+    case LSD_OPERATOR:
+      kernel = (cv::Mat_<int>(2, 2) << -1, -1, 1, 1);
+      anchor = cv::Point(0, 0);
+      break;
+    default:
+      throw std::runtime_error("Invalid op");
+      break;
   }
-      
-  cv::Mat gxImageSigned, gyImageSigned;
+
   cv::filter2D(smoothImage, gxImageSigned, CV_16SC1, kernel.t(), anchor);
   cv::filter2D(smoothImage, gyImageSigned, CV_16SC1, kernel, anchor);
-  const cv::Mat gxImage = cv::abs(gxImageSigned);
-  const cv::Mat gyImage = cv::abs(gyImageSigned);
+  const cv::MatExpr gxImage = cv::abs(gxImageSigned);
+  const cv::MatExpr gyImage = cv::abs(gyImageSigned);
   if (sumFlag)
   {
-    gradImage = gxImage + gyImage;
+    cv::add(gxImage, gyImage, gradImage);
   }
   else
   {
-    cv::sqrt(gxImage.mul(gxImage) + gyImage.mul(gyImage), gradImage);
+    cv::add(gxImage.mul(gxImage), gyImage.mul(gyImage), gradImage);
+    cv::sqrt(gradImage, gradImage);
   }
   gradImage.col(0).setTo(gradThresh - 1);
   gradImage.col(gradImage.cols - 1).setTo(gradThresh - 1);
@@ -348,9 +348,8 @@ void ED::ComputeGradient()
   gradImage.row(gradImage.rows - 1).setTo(gradThresh - 1);
   gradImg = (short *)gradImage.data;
 
-  dirImage = cv::Mat::zeros(gradImage.rows, gradImage.cols, CV_8UC1);
-  const cv::Mat maskThresh = gradImage >= gradThresh;
-  cv::Mat maskVertical, maskHorizontal;
+  dirImage.setTo(0);
+  cv::compare(gradImage, gradThresh, maskThresh, cv::CMP_GE);
   cv::bitwise_and(maskThresh, gxImage >= gyImage, maskVertical);
   cv::bitwise_and(maskThresh, gxImage < gyImage, maskHorizontal);
   dirImage.setTo(EDGE_VERTICAL, maskVertical);
@@ -412,7 +411,8 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
   std::vector<int> A;
   sortAnchorsByGradValue1(A);
   const auto sort_anchors_by_grad_value_tick = getTickCount();
-  lastEDProfile.sort_anchors_by_grad_value = (sort_anchors_by_grad_value_tick - alloc_tick) / getTickFrequency();
+  lastEDProfile.sort_anchors_by_grad_value =
+      (sort_anchors_by_grad_value_tick - alloc_tick) / getTickFrequency();
 
   // Now join the anchors starting with the anchor having the greatest gradient value
   int totalPixels = 0;

--- a/ED.cpp
+++ b/ED.cpp
@@ -5,13 +5,10 @@
 using namespace cv;
 using namespace std;
 
-ED::ED(const int _width, const int _height)
-{
-  prealloc(_width, _height);
-}
+ED::ED(const int _width, const int _height) { prealloc(_width, _height); }
 
 ED::ED(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh, int _scanInterval,
-            int _minPathLen, double _sigma, bool _sumFlag)
+       int _minPathLen, double _sigma, bool _sumFlag)
 {
   prealloc(_srcImage.cols, _srcImage.rows);
   process(_srcImage, _op, _gradThresh, _anchorThresh, _scanInterval, _minPathLen, _sigma, _sumFlag);
@@ -32,8 +29,26 @@ void ED::prealloc(const int _width, const int _height)
   chains.resize(width * height);
 }
 
-void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh, int _scanInterval,
-            int _minPathLen, double _sigma, bool _sumFlag)
+std::vector<cv::Point> ED::takePointVectorFromPool()
+{
+  if (m_point_vector_pool.size() > 0)
+  {
+    auto pvec = std::move(m_point_vector_pool.front());
+    m_point_vector_pool.pop_front();
+    return pvec;
+  }
+
+  return std::vector<cv::Point>();
+}
+
+void ED::returnPointVectorToPool(std::vector<cv::Point> point_vec)
+{
+  point_vec.clear();
+  m_point_vector_pool.push_back(std::move(point_vec));
+}
+
+void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anchorThresh,
+                 int _scanInterval, int _minPathLen, double _sigma, bool _sumFlag)
 {
   const auto start_tick = getTickCount();
   // Check parameters for sanity
@@ -58,7 +73,7 @@ void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anch
   srcImg = srcImage.data;
   const auto initialize_tick = getTickCount();
   lastEDProfile.initialize = (initialize_tick - start_tick) / getTickFrequency();
-  
+
   //// Detect Edges By Edge Drawing Algorithm  ////
 
   /*------------ SMOOTH THE IMAGE BY A GAUSSIAN KERNEL -------------------*/
@@ -79,18 +94,21 @@ void ED::process(Mat _srcImage, GradientOperator _op, int _gradThresh, int _anch
   /*------------ COMPUTE GRADIENT & EDGE DIRECTION MAPS -------------------*/
   ComputeGradient();
   const auto compute_gradient_tick = getTickCount();
-  lastEDProfile.compute_gradient = (compute_gradient_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDProfile.compute_gradient =
+      (compute_gradient_tick - gaussian_blur_tick) / getTickFrequency();
 
   /*------------ COMPUTE ANCHORS -------------------*/
   ComputeAnchorPoints();
   const auto compute_anchor_points_tick = getTickCount();
-  lastEDProfile.compute_anchor_points = (compute_anchor_points_tick - compute_gradient_tick) / getTickFrequency();
+  lastEDProfile.compute_anchor_points =
+      (compute_anchor_points_tick - compute_gradient_tick) / getTickFrequency();
 
   /*------------ JOIN ANCHORS -------------------*/
   JoinAnchorPointsUsingSortedAnchors();
   const auto join_anchor_points_using_sorted_anchors_tick = getTickCount();
   lastEDProfile.join_anchor_points_using_sorted_anchors =
-    (join_anchor_points_using_sorted_anchors_tick - compute_anchor_points_tick) / getTickFrequency();
+      (join_anchor_points_using_sorted_anchors_tick - compute_anchor_points_tick) /
+      getTickFrequency();
 }
 
 // This constructor for use of EDLines and EDCircle with ED given as constructor argument
@@ -225,8 +243,6 @@ ED::ED(short *_gradImg, uchar *_dirImg, int _width, int _height, int _gradThresh
                             // stable anchors.)
   }                         // end-else
 
-  segmentPoints.push_back(vector<Point>());  // create empty vector of points for segments
-
   JoinAnchorPointsUsingSortedAnchors();
 }
 
@@ -308,27 +324,27 @@ void ED::ComputeGradient()
   cv::Point anchor;
   switch (op)
   {
-  case PREWITT_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
-    anchor = cv::Point(-1, -1);
-    break;
-  case SOBEL_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -1, -2, -1, 0, 0, 0, 1, 2, 1);
-    anchor = cv::Point(-1, -1);
-    break;
-  case SCHARR_OPERATOR:
-    kernel = (cv::Mat_<int>(3, 3) << -3, -10, -3, 0, 0, 0, 3, 10, 3);
-    anchor = cv::Point(-1, -1);
-    break;
-  case LSD_OPERATOR:
-    kernel = (cv::Mat_<int>(2, 2) << -1, -1, 1, 1);
-    anchor = cv::Point(0, 0);
-    break;
-  default:
-    throw std::runtime_error("Invalid op");
-    break;
+    case PREWITT_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
+      anchor = cv::Point(-1, -1);
+      break;
+    case SOBEL_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -1, -2, -1, 0, 0, 0, 1, 2, 1);
+      anchor = cv::Point(-1, -1);
+      break;
+    case SCHARR_OPERATOR:
+      kernel = (cv::Mat_<int>(3, 3) << -3, -10, -3, 0, 0, 0, 3, 10, 3);
+      anchor = cv::Point(-1, -1);
+      break;
+    case LSD_OPERATOR:
+      kernel = (cv::Mat_<int>(2, 2) << -1, -1, 1, 1);
+      anchor = cv::Point(0, 0);
+      break;
+    default:
+      throw std::runtime_error("Invalid op");
+      break;
   }
-      
+
   cv::Mat gxImageSigned, gyImageSigned;
   cv::filter2D(smoothImage, gxImageSigned, CV_16SC1, kernel.t(), anchor);
   cv::filter2D(smoothImage, gyImageSigned, CV_16SC1, kernel, anchor);
@@ -403,8 +419,13 @@ void ED::ComputeAnchorPoints()
 void ED::JoinAnchorPointsUsingSortedAnchors()
 {
   const auto start_tick = getTickCount();
+  // return point vectors to the pool before the clear
+  for (int i = 0; i < static_cast<int>(segmentPoints.size()); ++i)
+  {
+    returnPointVectorToPool(std::move(segmentPoints[i]));
+  }
   segmentPoints.clear();
-  segmentPoints.push_back(vector<Point>());
+  segmentPoints.push_back(takePointVectorFromPool());
   const auto alloc_tick = getTickCount();
   lastEDProfile.join_anchor_points_alloc = (alloc_tick - start_tick) / getTickFrequency();
 
@@ -412,7 +433,8 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
   std::vector<int> A;
   sortAnchorsByGradValue1(A);
   const auto sort_anchors_by_grad_value_tick = getTickCount();
-  lastEDProfile.sort_anchors_by_grad_value = (sort_anchors_by_grad_value_tick - alloc_tick) / getTickFrequency();
+  lastEDProfile.sort_anchors_by_grad_value =
+      (sort_anchors_by_grad_value_tick - alloc_tick) / getTickFrequency();
 
   // Now join the anchors starting with the anchor having the greatest gradient value
   int totalPixels = 0;
@@ -980,7 +1002,8 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
       }  // end-if
 
       segmentNos++;
-      segmentPoints.push_back(vector<Point>());  // create empty vector of points for segments
+      segmentPoints.push_back(
+          takePointVectorFromPool());  // create empty vector of points for segments
 
       // Copy the rest of the long chains here
       for (int k = 2; k < noChains; k++)
@@ -1045,9 +1068,10 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
               noSegmentPixels++;
             }  // end-for
 
-            chains[chainNo].len = 0;                 // Mark as copied
-          }                                          // end-for
-          segmentPoints.push_back(vector<Point>());  // create empty vector of points for segments
+            chains[chainNo].len = 0;  // Mark as copied
+          }                           // end-for
+          segmentPoints.push_back(
+              takePointVectorFromPool());  // create empty vector of points for segments
           segmentNos++;
         }  // end-if
       }    // end-for
@@ -1058,6 +1082,7 @@ void ED::JoinAnchorPointsUsingSortedAnchors()
 
   // pop back last segment from vector
   // because of one preallocation in the beginning, it will always empty
+  returnPointVectorToPool(std::move(segmentPoints.back()));
   segmentPoints.pop_back();
 }
 

--- a/ED.h
+++ b/ED.h
@@ -60,7 +60,6 @@ struct Chain
 class ED
 {
  public:
-
   struct Profile
   {
     double initialize;
@@ -86,11 +85,10 @@ class ED
   void prealloc(const int _width, const int _height);
 
   void process(cv::Mat _srcImage, GradientOperator _op = PREWITT_OPERATOR, int _gradThresh = 20,
-     int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10, double _sigma = 1.0,
-     bool _sumFlag = true);
+               int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10,
+               double _sigma = 1.0, bool _sumFlag = true);
   int getWidth() const { return width; }
   int getHeight() const { return height; }
-  
 
   cv::Mat getEdgeImage();
   cv::Mat getAnchorImage();
@@ -138,6 +136,8 @@ class ED
   cv::Mat gradImage;
   cv::Mat gxImageSigned;
   cv::Mat gyImageSigned;
+  cv::Mat gxImage;
+  cv::Mat gyImage;
   cv::Mat maskThresh;
   cv::Mat maskVertical;
   cv::Mat maskHorizontal;

--- a/ED.h
+++ b/ED.h
@@ -17,6 +17,8 @@
 #ifndef _ED_
 #define _ED_
 
+#include <deque>
+
 #include <opencv2/opencv.hpp>
 #include "EDColor.h"
 
@@ -60,7 +62,6 @@ struct Chain
 class ED
 {
  public:
-
   struct Profile
   {
     double initialize;
@@ -86,11 +87,10 @@ class ED
   void prealloc(const int _width, const int _height);
 
   void process(cv::Mat _srcImage, GradientOperator _op = PREWITT_OPERATOR, int _gradThresh = 20,
-     int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10, double _sigma = 1.0,
-     bool _sumFlag = true);
+               int _anchorThresh = 0, int _scanInterval = 1, int _minPathLen = 10,
+               double _sigma = 1.0, bool _sumFlag = true);
   int getWidth() const { return width; }
   int getHeight() const { return height; }
-  
 
   cv::Mat getEdgeImage();
   cv::Mat getAnchorImage();
@@ -131,6 +131,9 @@ class ED
   static int LongestChain(std::vector<Chain> &chains, int root);
   static int RetrieveChainNos(std::vector<Chain> &chains, int root, std::vector<int> &chainNos);
 
+  std::vector<cv::Point> takePointVectorFromPool();
+  void returnPointVectorToPool(std::vector<cv::Point> point_vec);
+
   std::vector<cv::Point> anchorPoints;
 
   cv::Mat edgeImage;
@@ -151,6 +154,9 @@ class ED
   std::vector<cv::Point> pixels;
   std::vector<StackNode> stack;
   std::vector<Chain> chains;
+
+  // pool for cv::Point vector
+  std::deque<std::vector<cv::Point>> m_point_vector_pool;
 };
 
 #endif

--- a/ED.h
+++ b/ED.h
@@ -136,6 +136,11 @@ class ED
   cv::Mat edgeImage;
   cv::Mat dirImage;
   cv::Mat gradImage;
+  cv::Mat gxImageSigned;
+  cv::Mat gyImageSigned;
+  cv::Mat maskThresh;
+  cv::Mat maskVertical;
+  cv::Mat maskHorizontal;
 
   uchar *dirImg;   // pointer to direction image data
   short *gradImg;  // pointer to gradient image data

--- a/ED.h
+++ b/ED.h
@@ -138,6 +138,7 @@ class ED
   cv::Mat gyImageSigned;
   cv::Mat gxImage;
   cv::Mat gyImage;
+  cv::Mat maskImage;
   cv::Mat maskThresh;
   cv::Mat maskVertical;
   cv::Mat maskHorizontal;

--- a/ED.h
+++ b/ED.h
@@ -139,14 +139,14 @@ class ED
   cv::Mat edgeImage;
   cv::Mat dirImage;
   cv::Mat gradImage;
-  cv::Mat gxImageSigned;
-  cv::Mat gyImageSigned;
-  cv::Mat gxImage;
-  cv::Mat gyImage;
-  cv::Mat maskImage;
-  cv::Mat maskThresh;
-  cv::Mat maskVertical;
-  cv::Mat maskHorizontal;
+
+  // Buffer with the same size as srcImage
+  // Use these locally and
+  // don't share data among functions with these
+  cv::Mat buffer0;
+  cv::Mat buffer1;
+  cv::Mat buffer2;
+  cv::Mat buffer3;
 
   uchar *dirImg;   // pointer to direction image data
   short *gradImg;  // pointer to gradient image data

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -96,9 +96,13 @@ void EDPF::validateEdgeSegments()
 void EDPF::ComputePrewitt3x3()
 {
   const cv::Mat kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
-  cv::filter2D(srcImage, gxImageSigned, CV_16SC1, kernel.t());
-  cv::filter2D(srcImage, gyImageSigned, CV_16SC1, kernel);
-  cv::add(cv::abs(gxImageSigned), cv::abs(gyImageSigned), gradImage);
+  cv::Mat &gxImage = buffer0;
+  cv::Mat &gyImage = buffer1;
+  cv::filter2D(srcImage, gxImage, CV_16SC1, kernel.t());
+  cv::filter2D(srcImage, gyImage, CV_16SC1, kernel);
+  cv::absdiff(gxImage, cv::Scalar::all(0), gxImage);  // gxImage = cv::abs(gxImage)
+  cv::absdiff(gyImage, cv::Scalar::all(0), gyImage);
+  cv::add(gxImage, gyImage, gradImage);
   gradImage.col(0).setTo(0);
   gradImage.col(gradImage.cols - 1).setTo(0);
   gradImage.row(0).setTo(0);

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -3,11 +3,7 @@
 using namespace cv;
 using namespace std;
 
-EDPF::EDPF(const int _width, const int _height)
-: ED(_width, _height)
-{
-  prealloc();
-}
+EDPF::EDPF(const int _width, const int _height) : ED(_width, _height) { prealloc(); }
 /*
 EDPF::EDPF(Mat srcImage) : ED(srcImage, PREWITT_OPERATOR, 11, 3)
 {
@@ -20,7 +16,8 @@ EDPF::EDPF(Mat srcImage) : ED(srcImage, PREWITT_OPERATOR, 11, 3)
 
   validateEdgeSegments();
   const auto validate_edge_segments_tick = getTickCount();
-  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) /
+getTickFrequency();
 }
 */
 EDPF::EDPF(Mat srcImage) : ED(srcImage.cols, srcImage.rows)
@@ -39,15 +36,12 @@ EDPF::EDPF(ED obj) : ED(obj)
 
 EDPF::EDPF(EDColor obj) : ED(obj) {}
 
-void EDPF::prealloc()
-{
-  H.reserve(MAX_GRAD_VALUE);
-}
+void EDPF::prealloc() { H.reserve(MAX_GRAD_VALUE); }
 
 void EDPF::process(cv::Mat _srcImage)
 {
   ED::process(_srcImage, PREWITT_OPERATOR, 11, 3);
-  
+
   // Validate Edge Segments
   const auto start_tick = getTickCount();
   sigma /= 2.5;
@@ -57,7 +51,8 @@ void EDPF::process(cv::Mat _srcImage)
 
   validateEdgeSegments();
   const auto validate_edge_segments_tick = getTickCount();
-  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDPFProfile.validate_edge_segments =
+      (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
 }
 
 void EDPF::validateEdgeSegments()
@@ -101,7 +96,6 @@ void EDPF::validateEdgeSegments()
 void EDPF::ComputePrewitt3x3()
 {
   const cv::Mat kernel = (cv::Mat_<int>(3, 3) << -1, -1, -1, 0, 0, 0, 1, 1, 1);
-  cv::Mat gxImageSigned, gyImageSigned;
   cv::filter2D(srcImage, gxImageSigned, CV_16SC1, kernel.t());
   cv::filter2D(srcImage, gyImageSigned, CV_16SC1, kernel);
   cv::add(cv::abs(gxImageSigned), cv::abs(gyImageSigned), gradImage);
@@ -123,7 +117,6 @@ void EDPF::ComputePrewitt3x3()
 
   // Compute probability function H
   const int size = (width - 2) * (height - 2);
-  
   for (int i = grads.size() - 1; i > 0; i--) grads[i - 1] += grads[i];
 
   H.clear();

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -104,7 +104,7 @@ void EDPF::ComputePrewitt3x3()
   cv::Mat gxImageSigned, gyImageSigned;
   cv::filter2D(srcImage, gxImageSigned, CV_16SC1, kernel.t());
   cv::filter2D(srcImage, gyImageSigned, CV_16SC1, kernel);
-  gradImage = cv::abs(gxImageSigned) + cv::abs(gyImageSigned);
+  cv::add(cv::abs(gxImageSigned), cv::abs(gyImageSigned), gradImage);
   gradImage.col(0).setTo(0);
   gradImage.col(gradImage.cols - 1).setTo(0);
   gradImage.row(0).setTo(0);
@@ -113,7 +113,9 @@ void EDPF::ComputePrewitt3x3()
 
   double max_grad_value = static_cast<double>(MAX_GRAD_VALUE);
   cv::minMaxLoc(gradImage, nullptr, &max_grad_value);
-  std::vector<int> grads(static_cast<int>(max_grad_value) + 1, 0);
+  grads.clear();
+  grads.resize(static_cast<int>(max_grad_value) + 1);
+  std::fill(grads.begin(), grads.end(), 0);
   for (int i = 0; i < gradImage.total(); ++i)
   {
     grads[gradImg[i]]++;

--- a/EDPF.cpp
+++ b/EDPF.cpp
@@ -3,11 +3,7 @@
 using namespace cv;
 using namespace std;
 
-EDPF::EDPF(const int _width, const int _height)
-: ED(_width, _height)
-{
-  prealloc();
-}
+EDPF::EDPF(const int _width, const int _height) : ED(_width, _height) { prealloc(); }
 /*
 EDPF::EDPF(Mat srcImage) : ED(srcImage, PREWITT_OPERATOR, 11, 3)
 {
@@ -20,7 +16,8 @@ EDPF::EDPF(Mat srcImage) : ED(srcImage, PREWITT_OPERATOR, 11, 3)
 
   validateEdgeSegments();
   const auto validate_edge_segments_tick = getTickCount();
-  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) /
+getTickFrequency();
 }
 */
 EDPF::EDPF(Mat srcImage) : ED(srcImage.cols, srcImage.rows)
@@ -39,15 +36,12 @@ EDPF::EDPF(ED obj) : ED(obj)
 
 EDPF::EDPF(EDColor obj) : ED(obj) {}
 
-void EDPF::prealloc()
-{
-  H.reserve(MAX_GRAD_VALUE);
-}
+void EDPF::prealloc() { H.reserve(MAX_GRAD_VALUE); }
 
 void EDPF::process(cv::Mat _srcImage)
 {
   ED::process(_srcImage, PREWITT_OPERATOR, 11, 3);
-  
+
   // Validate Edge Segments
   const auto start_tick = getTickCount();
   sigma /= 2.5;
@@ -57,7 +51,8 @@ void EDPF::process(cv::Mat _srcImage)
 
   validateEdgeSegments();
   const auto validate_edge_segments_tick = getTickCount();
-  lastEDPFProfile.validate_edge_segments = (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
+  lastEDPFProfile.validate_edge_segments =
+      (validate_edge_segments_tick - gaussian_blur_tick) / getTickFrequency();
 }
 
 void EDPF::validateEdgeSegments()
@@ -121,7 +116,7 @@ void EDPF::ComputePrewitt3x3()
 
   // Compute probability function H
   const int size = (width - 2) * (height - 2);
-  
+
   for (int i = grads.size() - 1; i > 0; i--) grads[i - 1] += grads[i];
 
   H.clear();
@@ -240,9 +235,9 @@ void EDPF::ExtractNewSegments()
         // A new segment. Accepted only only long enough (whatever that means)
         // segments[noSegments].pixels = &map->segments[i].pixels[start];
         // segments[noSegments].noPixels = len;
-        validSegments.push_back(vector<Point>());
-        vector<Point> subVec(&segmentPoints[i][start], &segmentPoints[i][end - 1]);
-        validSegments[noSegments] = subVec;
+        std::vector<cv::Point> subVec = takePointVectorFromPool();
+        subVec.insert(subVec.begin(), &segmentPoints[i][start], &segmentPoints[i][end - 1]);
+        validSegments.push_back(subVec);
         noSegments++;
       }  // end-else
 
@@ -251,6 +246,11 @@ void EDPF::ExtractNewSegments()
   }    // end-for
 
   // Copy to ed
+  // before copying return vectors to the pool
+  for (int i = 0; i < static_cast<int>(segmentPoints.size()); ++i)
+  {
+    returnPointVectorToPool(std::move(segmentPoints[i]));
+  }
   segmentPoints = validSegments;
 }
 

--- a/EDPF.h
+++ b/EDPF.h
@@ -25,7 +25,6 @@
 class EDPF : public ED
 {
  public:
-
   struct Profile
   {
     double gaussian_blur;
@@ -47,6 +46,7 @@ class EDPF : public ED
   std::vector<double> H;
   int np;
   Profile lastEDPFProfile;
+  std::vector<int> grads;
 
   void validateEdgeSegments();
   void ComputePrewitt3x3();  // differs from base class's prewit function (calculates H)


### PR DESCRIPTION
This is intensive optimization for speed and discarding readability. 

* pool and reuse vector of cv::Point
* keep local buffer allocated
* don't allocate tmp images