### PR TITLE
fix cv::sqrt error

### DIFF
--- a/ED.cpp
+++ b/ED.cpp
@@ -365,7 +365,7 @@ void ED::ComputeGradient()
     cv::multiply(gyImage, gyImage, gyImageSquared);
     cv::add(gxImageSquared, gyImageSquared, gxImageSquared);
     // convert 32FC1 for cv::sqrt
-    cv::Mat gradFloatImage = buffer3;
+    cv::Mat &gradFloatImage = buffer3;
     gxImageSquared.convertTo(gradFloatImage, CV_32FC1);
     cv::sqrt(gradFloatImage, gradFloatImage);
     gradFloatImage.convertTo(gradImage, CV_16SC1);

--- a/ED.cpp
+++ b/ED.cpp
@@ -363,8 +363,12 @@ void ED::ComputeGradient()
     cv::Mat &gyImageSquared = buffer3;
     cv::multiply(gxImage, gxImage, gxImageSquared);
     cv::multiply(gyImage, gyImage, gyImageSquared);
-    cv::add(gxImageSquared, gyImageSquared, gradImage);
-    cv::sqrt(gradImage, gradImage);
+    cv::add(gxImageSquared, gyImageSquared, gxImageSquared);
+    // convert 32FC1 for cv::sqrt
+    cv::Mat gradFloatImage = buffer3;
+    gxImageSquared.convertTo(gradFloatImage, CV_32FC1);
+    cv::sqrt(gradFloatImage, gradFloatImage);
+    gradFloatImage.convertTo(gradImage, CV_16SC1);
   }
   gradImage.col(0).setTo(gradThresh - 1);
   gradImage.col(gradImage.cols - 1).setTo(gradThresh - 1);


### PR DESCRIPTION
the current implementation `CV_16SC1` is passed to `cv::sqrt` when `sumFlag` is `false`, which causes run time error.
this PR fixes the error to convert `CV_32FC1` for `cv::sqrt`.

https://answers.opencv.org/question/3070/cvsqrt-and-cvpow-throwing-exceptions/